### PR TITLE
Add CI image for building the nightly releases

### DIFF
--- a/.ci-dockerfiles/nightly-builder/Dockerfile
+++ b/.ci-dockerfiles/nightly-builder/Dockerfile
@@ -1,0 +1,10 @@
+FROM ponylang/ponyc:alpine
+
+RUN apk update \
+  && apk upgrade \
+  && apk upgrade curl \
+  && apk add --update \
+  py-pip \
+  libressl-dev \
+  curl \
+  && pip install cloudsmith-cli

--- a/.ci-dockerfiles/nightly-builder/README.md
+++ b/.ci-dockerfiles/nightly-builder/README.md
@@ -1,0 +1,25 @@
+# Overview
+
+This docker image is used to build the `ponyup` nightly releases.
+
+# Build image
+
+```bash
+docker build -t ponylang/ponyup:nightly-builder .
+```
+
+# Run image to test
+
+Will get you a bash shell in the image to try cloning Pony into where you can test a build to make sure everything will work before pushing:
+
+```bash
+docker run --name ponyup-nightly-builder --rm -i -t ponylang/ponyup:nightly-builder bash
+```
+
+# Push to dockerhub
+
+You'll need credentials for the ponylang dockerhub account. Talk to @jemc or @seantallen for access
+
+```bash
+docker push ponylang/ponyup:nightly-builder
+```

--- a/.ci-scripts/x86-64-unknown-linux-nightly.bash
+++ b/.ci-scripts/x86-64-unknown-linux-nightly.bash
@@ -39,7 +39,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyup"
 # Build ponyup installation
 echo "Building ponyup..."
 make install prefix="${BUILD_DIR}" arch=${ARCH} version="${PONYUP_VERSION}" \
-  static=true linker=bfd
+  ssl=0.9.0 static=true linker=bfd
 
 # Package it all up
 echo "Creating .tar.gz of ponyup..."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,9 @@ orbs:
 jobs:
   x86-64-unknown-linux-nightly:
     docker:
-      - image: ponylang/ponyc:alpine
+      - image: ponylang/ponyup:nightly-builder
     steps:
-      - run: apk add --update py-pip perl
-      - run: pip install cloudsmith-cli
       - checkout
-      - run: .ci-scripts/install-openssl.sh
       - run: bash .ci-scripts/x86-64-unknown-linux-nightly.bash ${CLOUDSMITH_API_KEY}
       - zulip/status
 
@@ -54,6 +51,22 @@ jobs:
       - zulip/status:
           fail_only: true
 
+  update-nightly-builder-image:
+    docker:
+      - image: ponylang/ponyc-ci:docker-builder
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build nightly-builder Docker image
+          command: docker build -t ponylang/ponyup:nightly-builder .ci-dockerfiles/nightly-builder
+      - run:
+          name: Publish nightly-builder to DockerHub
+          command: |
+            docker login -u "$DOCKERHUB_USERNAME" -p "$DOCKERHUB_PASSWORD"
+            docker push ponylang/ponyup:nightly-builder
+      - zulip/status
+
 workflows:
   version: 2
   every-commit:
@@ -79,10 +92,21 @@ workflows:
   create-and-upload-nightly-release:
     triggers:
       - schedule:
-          cron: "0 3 * * *"
+          cron: "0 0 * * *"
           filters:
             branches:
               only: master
     jobs:
       - x86-64-unknown-linux-nightly:
+          context: org-global
+
+  daily-nightly-builder-image-update:
+    triggers:
+      - schedule:
+          cron: "0 5 * * *"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - update-nightly-builder-image:
           context: org-global


### PR DESCRIPTION
There were several changes needed to get SSL and nightly builds working.                                                                                      As part of this change, we have added a CI image specificly for building                                                                                     the nightly releases as well as a CI job to keep it updated.                                                                                                  
                                                                                                                                                           Because we build the nightlies in alpine, we have to use SSL 0.9.0                                                                                        as it is what the libressl there supports.  