### PR TITLE
Improve message for package not found

### DIFF
--- a/cmd/sync_monitor.pony
+++ b/cmd/sync_monitor.pony
@@ -60,7 +60,11 @@ actor SyncMonitor
       try
         source.parse_sync(consume res)?
       else
-        _log.err("requested pony version was not found")
+        _log.err("".join(
+          [ "requested package, "
+            package; "-"; source.name()
+            ", was not found"
+          ].values()))
         return
       end
 


### PR DESCRIPTION
This new message looks like the following:
`$ ponyup update stable release`
`error: requested package, stable-release, was not found`