### PR TITLE
Make default SSL version match our test and build environments

### DIFF
--- a/.ci-scripts/release/x86-64-unknown-linux-nightly.bash
+++ b/.ci-scripts/release/x86-64-unknown-linux-nightly.bash
@@ -42,7 +42,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyup"
 # Build ponyup installation
 echo "Building ponyup..."
 make install prefix="${BUILD_DIR}" arch=${ARCH} version="${PONYUP_VERSION}" \
-  ssl=0.9.0 static=true linker=bfd
+  static=true linker=bfd
 
 # Package it all up
 echo "Creating .tar.gz of ponyup..."

--- a/.ci-scripts/release/x86-64-unknown-linux-release.bash
+++ b/.ci-scripts/release/x86-64-unknown-linux-release.bash
@@ -56,7 +56,7 @@ ASSET_DESCRIPTION="https://github.com/ponylang/ponyup"
 # Build ponyup installation
 echo -e "\e[34mBuilding ponyup..."
 make install prefix="${BUILD_DIR}" arch=${ARCH} \
-  version="${APPLICATION_VERSION}" ssl=0.9.0 static=true linker=bfd
+  version="${APPLICATION_VERSION}" static=true linker=bfd
 
 # Package it all up
 echo -e "\e[34mCreating .tar.gz of ponyup..."

--- a/.ci-scripts/test-bootstrap.sh
+++ b/.ci-scripts/test-bootstrap.sh
@@ -19,4 +19,4 @@ ponyup update corral nightly
 ponyup update stable nightly
 
 make clean
-make ssl=0.9.0
+make

--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Test with a recent ponyc from master
-        run: make test ssl=0.9.0
+        run: make test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,7 +39,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Unit tests
-        run: make test ssl=0.9.0
+        run: make test
       - name: Bootstrap test
         run: .ci-scripts/test-bootstrap.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY cmd /src/ponyup/cmd/
 
 WORKDIR /src/ponyup
 
-RUN make ssl=0.9.0 arch=x86-64 static=true linker=bfd config=release
+RUN make arch=x86-64 static=true linker=bfd config=release
 
 FROM alpine:3.10
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ arch ?=
 static ?= false
 linker ?=
 
-ssl ?= 1.1.x
+ssl ?= 0.9.0
 PONYC_FLAGS ?=
 
 BUILD_DIR ?= build/$(config)


### PR DESCRIPTION
We use libressl, which matches the openssl 0.9.0 API, in all our
CI environments.

This change switches the default in our Makefile from 1.1.x to 0.9.0
thereby making maintenance of all our scripts much easier. By doing this,
all the release scripts for ponyup will be the same as changelog-tool and
pony-stable.

That is going to make maintenance on the scripts much easier as we can
copy changes around.

This is a prelude to issue #35 and will make #35 much less error prone.