### PR TITLE
Make sure we are always using the most recent base images

### DIFF
--- a/.ci-scripts/release/build-docker-images-on-release.bash
+++ b/.ci-scripts/release/build-docker-images-on-release.bash
@@ -53,10 +53,10 @@ VERSION="${GITHUB_REF/refs\/tags\//}"
 
 # Build and push :VERSION tag e.g. ponylang/ponyup:0.32.1
 DOCKER_TAG=${GITHUB_REPOSITORY}:"${VERSION}"
-docker build -t "${DOCKER_TAG}" .
+docker build --pull -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"
 
 # Build and push "release" tag e.g. ponylang/ponyup:release
 DOCKER_TAG=${GITHUB_REPOSITORY}:release
-docker build -t "${DOCKER_TAG}" .
+docker build --pull -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"

--- a/.ci-scripts/release/build-latest-docker-images.bash
+++ b/.ci-scripts/release/build-latest-docker-images.bash
@@ -34,5 +34,5 @@ set -o nounset
 
 # Build and push "latest" tag e.g. ponylang/ponyup:latest
 DOCKER_TAG=${GITHUB_REPOSITORY}:latest
-docker build -t "${DOCKER_TAG}" .
+docker build --pull -t "${DOCKER_TAG}" .
 docker push "${DOCKER_TAG}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Docker build
-        run: "docker build ."
+        run: "docker build --pull ."
 
   shellcheck:
     name: Shellcheck


### PR DESCRIPTION
Run a `docker build --pull` to assure we don't build any Docker images
using a cached version of a base image if a more recent version is
available.