### PR TITLE
Use platform-specific storage paths

### DIFF
--- a/.ci-scripts/test-bootstrap.sh
+++ b/.ci-scripts/test-bootstrap.sh
@@ -12,7 +12,7 @@ rm -rf \
 
 cat ponyup-init.sh | sh -s -- --prefix=/usr/local
 
-export PATH=$HOME/.pony/ponyup/bin:$PATH
+export PATH=$HOME/.local/share/ponyup/bin:$PATH
 ponyup update ponyc nightly --libc=${libc}
 ponyup update changelog-tool nightly
 ponyup update corral nightly

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ ponyup update ponyc nightly
 ```bash
 ponyup update ponyc release
 ```
-These commands will download the chosen version of ponyc and install it to `$HOME/.pony/ponyup/bin` by default. See the instructions below for how to set the install path and manage Pony applications.
+These commands will download the chosen version of ponyc and install it to `$HOME/.local/share/ponyup/bin` by default. See the instructions below for how to set the install path and manage Pony applications.
 
 ### Set install prefix
 
-By default, ponyup will create its root directory in `$HOME/.pony`. This prefix can be set manually with the `--prefix` (or `-p`) option. All packages selected as default will be symbolically linked into `${prefix}/ponyup/bin`. So, by default, `ponyup update release ponyc` will install `ponyc` to `$HOME/.pony/ponyup/bin/ponyc`.
+By default, ponyup will create its root directory in `$HOME/.local/share`. This prefix can be set manually with the `--prefix` (or `-p`) option. All packages selected as default will be symbolically linked into `${prefix}/ponyup/bin`. So, by default, `ponyup update release ponyc` will install `ponyc` to `$HOME/.local/share/ponyup/bin/ponyc`.
 
 ### Install a previous package version
 

--- a/bundle.json
+++ b/bundle.json
@@ -2,19 +2,23 @@
   "deps": [
     {
       "type": "github",
-      "repo": "ponylang/http"
+      "repo": "ponylang/http",
+      "tag": "0.2.4"
     },
     {
       "type": "github",
-      "repo": "ponylang/net-ssl"
+      "repo": "ponylang/net-ssl",
+      "tag": "1.0.0"
     },
     {
       "type": "github",
-      "repo": "ponylang/crypto"
+      "repo": "ponylang/crypto",
+      "tag": "1.0.0"
     },
     {
       "type": "github",
-      "repo": "ponylang/pony-appdirs"
+      "repo": "ponylang/pony-appdirs",
+      "tag": "0.1.0"
     }
   ]
 }

--- a/bundle.json
+++ b/bundle.json
@@ -11,6 +11,10 @@
     {
       "type": "github",
       "repo": "ponylang/crypto"
+    },
+    {
+      "type": "github",
+      "repo": "ponylang/pony-appdirs"
     }
   ]
 }

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-default_prefix="$HOME/.pony/ponyup"
+default_prefix="$HOME/.local/share"
 
 exit_usage() {
   printf "%s\n\n" "ponyup-init.sh"
@@ -21,20 +21,21 @@ json_field() {
     sed 's/[",]//g'
 }
 
-prefix=${default_prefix}
+prefix=default_prefix
 for arg in "$@"; do
   case "${arg}" in
   "--prefix="*)
     prefix=${arg##--prefix=}
-    echo "${prefix}"
     ;;
   *)
     exit_usage
     ;;
   esac
 done
+ponyup_root="${prefix}/ponyup"
+echo "ponyup_root = ${ponyup_root}"
 
-mkdir -p "${prefix}/bin"
+mkdir -p "${ponyup_root}/bin"
 
 platform_os=$(uname -s)
 if [ "$(echo "${platform_os}" | cut -c1-5)" != "Linux" ]; then
@@ -88,12 +89,12 @@ fi
 echo "checksum ok"
 
 tar -xzf "${tmp_dir}/${filename}" -C "${tmp_dir}"
-mv "$(find ${tmp_dir} -name ponyup -type f)" "${prefix}/bin/ponyup"
+mv "$(find ${tmp_dir} -name ponyup -type f)" "${ponyup_root}/bin/ponyup"
 
-echo "ponyup placed in ${prefix}/bin"
+echo "ponyup placed in ${ponyup_root}/bin"
 
-if ! echo "$PATH" | grep -q "${prefix}/bin"; then
+if ! echo "$PATH" | grep -q "${ponyup_root}/bin"; then
   printf "\n%s\n\n  %s\n\n" \
-    "I recommend adding ${prefix}/bin to \$PATH:" \
-    "export PATH=${prefix}/bin:\$PATH"
+    "I recommend adding ${ponyup_root}/bin to \$PATH:" \
+    "export PATH=${ponyup_root}/bin:\$PATH"
 fi


### PR DESCRIPTION
ponyup now uses [appdirs](https://github.com/ponylang/appdirs) to detect platform-specific user directories to store data. For example, on Linux we were previously using `$HOME/.pony/ponyup` as the application data root directory. We now use `$HOME/.local/share/ponyup`.

Closes #50 