### PR TITLE
pass default platform to sync and select

### DIFF
--- a/cmd/main.pony
+++ b/cmd/main.pony
@@ -115,7 +115,7 @@ actor Main is PonyupNotify
           command.arg("package").string(),
           chan(0)?,
           try chan(1)? else "latest" end,
-          command.option("platform").string().split("-"))?
+          platform.string().split("-"))?
       else
         log(Err, "".join(
           [ "unexpected selection: "
@@ -135,7 +135,7 @@ actor Main is PonyupNotify
           command.arg("package").string(),
           chan(0)?,
           try chan(1)? else "latest" end,
-          command.option("platform").string().split("-"))?
+          platform.string().split("-"))?
       else
         log(Err, "".join(
           [ "unexpected selection: "


### PR DESCRIPTION
This allows the sync and select commands to use the default platform dropped by the init script. See #63.