### PR TITLE
Add Fedora bootstrap test

### DIFF
--- a/.ci-dockerfiles/fedora-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/fedora-bootstrap-tester/Dockerfile
@@ -1,0 +1,12 @@
+FROM fedora:31
+
+RUN dnf update -y \
+  && dnf upgrade -y \
+  && dnf install -y \
+     gcc \
+     curl \
+     findutils \
+     git \
+     libatomic \
+     openssl-devel \
+     make

--- a/.ci-dockerfiles/fedora-bootstrap-tester/build-and-push.bash
+++ b/.ci-dockerfiles/fedora-bootstrap-tester/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build --pull -t "ponylang/ponyup-ci-fedora-bootstrap-tester:${TODAY}" \
+  "${DOCKERFILE_DIR}"
+docker push "ponylang/ponyup-ci-fedora-bootstrap-tester:${TODAY}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,18 @@ jobs:
       - name: Bootstrap test
         run: .ci-scripts/test-bootstrap.sh
 
+  fedora-bootstrap:
+    name: Test bootstrapping on Fedora
+    runs-on: ubuntu-latest
+    container:
+        image: ponylang/ponyup-ci-fedora-bootstrap-tester:20200101
+    steps:
+      - uses: actions/checkout@v1
+      - name: Bootstrap test
+        run: |
+          export ssl=1.1.x
+          .ci-scripts/test-bootstrap.sh
+
   ubuntu-bootstrap:
     name: Test bootstrapping on Ubuntu
     runs-on: ubuntu-latest


### PR DESCRIPTION
A user reported that `cc -dumpmachine` didn't return either
*-gnu nor *-musl. This caused the init script to error out.

The init script has since been changed, however, we don't want to
have a regression. This commit adds testing bootstrap on Fedora in
addition to Alpine and Ubuntu. This gives us better coverage for
differences that we are aware of.