### PR TITLE
Allow for ponyup-init.sh to only change on releases

### DIFF
--- a/.ci-scripts/release/start-a-release.bash
+++ b/.ci-scripts/release/start-a-release.bash
@@ -102,6 +102,11 @@ git push ${PUSH_TO} master
 echo -e "\e[34mPushing ${VERSION} tag\e[0m"
 git push ${PUSH_TO} "${VERSION}"
 
+# add special "latest-release" tag that we move to point to latest release
+# this tag is what we have people use to install ponyup-init.sh via curl
+git tag --force latest-release
+git push --force ${PUSH_TO} latest-release
+
 # pull again, just in case, odds of this being needed are really slim
 git pull
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This project is currently beta software.
 ### Install ponyup
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/master/ponyup-init.sh | sh
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
 ```
 
 ### Install Pony


### PR DESCRIPTION
Currently, any change on master is immediately reflected in a
change for end users. This happens because we have them download
from master. This can and has lead to bugs being exposed
to users.

With this change, we will instead have a tag that gets moved on each
release that will instead be used. Having users download the "latest-release"
tagged version of ponyup-init.sh will allow us to protect users from
random breakage.

After this is approved but before it is merged, we need to create an
initial "latest-release" tag so that the new url in README.md will work
prior to the next release.