### PR TITLE
fix missing sha256sum command and print info for fish shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ All notable changes to this project will be documented in this file. This projec
 ### Fixed
 
 - Include initial ponyup package in lockfile ([PR #89](https://github.com/ponylang/ponyup/pull/89))
+- Use `shasum` if `sha256sum` command is missing, or exit with error message ([PR #92](https://github.com/ponylang/ponyup/pull/92))
 
 ### Added
 
 - Colorize important ponyup-init.sh output ([PR #81](https://github.com/ponylang/ponyup/pull/81))
+- Support showing `$PATH` message for [fish shell](https://fish.sh) ([PR #92](https://github.com/ponylang/ponyup/pull/92))
 
 ### Changed
 

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -87,18 +87,18 @@ platform_triple="${platform_triple_cpu}-${platform_triple_os}"
 case "${uname_s}" in
 Linux*)
   case $(cc -dumpmachine) in
-    *gnu)
-      platform_triple="${platform_triple}-gnu"
-      ;;
-    *musl)
-      platform_triple="${platform_triple}-musl"
-      ;;
-    *)
-      printf "%bUnable to determine libc type.\n" "${BLUE}"
-      printf "If you are using a musl libc based Linux, you'll need to use\n"
-      printf "%b--platform=musl%b when installing ponyc.%b\n" \
-        "${YELLOW}" "${BLUE}" "${DEFAULT}"
-      ;;
+  *gnu)
+    platform_triple="${platform_triple}-gnu"
+    ;;
+  *musl)
+    platform_triple="${platform_triple}-musl"
+    ;;
+  *)
+    printf "%bUnable to determine libc type.\n" "${BLUE}"
+    printf "If you are using a musl libc based Linux, you'll need to use\n"
+    printf "%b--platform=musl%b when installing ponyc.%b\n" \
+      "${YELLOW}" "${BLUE}" "${DEFAULT}"
+    ;;
   esac
   ;;
 esac
@@ -161,17 +161,17 @@ printf "%bponyup placed in %b${ponyup_root}/bin%b\n" \
 
 if ! echo "$PATH" | grep -q "${ponyup_root}/bin"; then
   case "${SHELL}" in
-    *fish)
-      printf "%bYou should add %b${ponyup_root}/bin%b to \$PATH:%b\n" \
-        "${BLUE}" "${YELLOW}" "${BLUE}" "${DEFAULT}"
-      printf "%bset -g fish_user_paths ${ponyup_root}/bin \$fish_user_paths%b\n" \
-        "${YELLOW}" "${DEFAULT}"
+  *fish)
+    printf "%bYou should add %b${ponyup_root}/bin%b to \$PATH:%b\n" \
+      "${BLUE}" "${YELLOW}" "${BLUE}" "${DEFAULT}"
+    printf "%bset -g fish_user_paths ${ponyup_root}/bin \$fish_user_paths%b\n" \
+      "${YELLOW}" "${DEFAULT}"
     ;;
-    *)
-      printf "%bYou should add %b${ponyup_root}/bin%b to \$PATH:%b\n" \
-        "${BLUE}" "${YELLOW}" "${BLUE}" "${DEFAULT}"
-      printf "%bexport PATH=${ponyup_root}/bin:\$PATH%b\n" \
-        "${YELLOW}" "${DEFAULT}"
+  *)
+    printf "%bYou should add %b${ponyup_root}/bin%b to \$PATH:%b\n" \
+      "${BLUE}" "${YELLOW}" "${BLUE}" "${DEFAULT}"
+    printf "%bexport PATH=${ponyup_root}/bin:\$PATH%b\n" \
+      "${YELLOW}" "${DEFAULT}"
     ;;
   esac
 fi

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -2,6 +2,7 @@
 
 set -o errexit
 set -o nounset
+set -o pipefail
 
 default_prefix="$HOME/.local/share"
 default_repository="releases"
@@ -33,7 +34,7 @@ shasumCommand() {
   elif command -v shasum > /dev/null 2>&1; then
     shasum --algorithm 256 "$@"
   else 
-    echo "No checksum command!"
+    printf "%bNo checksum command found.%b\n" "${RED}" "${DEFAULT}" >&2
     exit 1
   fi
 }
@@ -144,7 +145,7 @@ curl "${dl_url}" -o "${tmp_dir}/${filename}"
 dl_checksum="$(shasumCommand "${tmp_dir}/${filename}" | awk '{ print $1 }')"
 
 if [ "${dl_checksum}" != "${checksum}" ]; then
-  printf "%bmchecksum mismatch:\n" "${RED}"
+  printf "%bchecksum mismatch:\n" "${RED}"
   printf "    expected: %b${checksum}%b\n" "${BLUE}" "${RED}"
   printf "  calculated: %b${dl_checksum}%b\n" "${YELLOW}" "${DEFAULT}"
 

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -27,17 +27,6 @@ BLUE="\e[34m"
 RED="\e[31m"
 YELLOW="\e[33m"
 
-shasumCommand() {
-  if command -v sha256sum > /dev/null 2>&1; then
-    sha256sum "$@"
-  elif command -v shasum > /dev/null 2>&1; then
-    shasum --algorithm 256 "$@"
-  else 
-    printf "%bNo checksum command found.%b\n" "${RED}" "${DEFAULT}"
-    exit 1
-  fi
-}
-
 prefix="${default_prefix}"
 repository="${default_repository}"
 for arg in "$@"; do
@@ -103,6 +92,15 @@ Linux*)
   ;;
 esac
 
+if command -v sha256sum > /dev/null 2>&1; then
+  sha256sum='sha256sum'
+elif command -v shasum > /dev/null 2>&1; then
+  sha256sum='shasum --algorithm 256'
+else 
+  printf "%bNo checksum command found.%b\n" "${RED}" "${DEFAULT}"
+  exit 1
+fi
+
 ponyup_root="${prefix}/ponyup"
 echo "ponyup_root = ${ponyup_root}"
 
@@ -141,7 +139,7 @@ echo "downloading ${filename}"
 
 curl "${dl_url}" -o "${tmp_dir}/${filename}"
 
-dl_checksum="$(shasumCommand "${tmp_dir}/${filename}" | awk '{ print $1 }')"
+dl_checksum="$(${sha256sum} "${tmp_dir}/${filename}" | awk '{ print $1 }')"
 
 if [ "${dl_checksum}" != "${checksum}" ]; then
   printf "%bchecksum mismatch:\n" "${RED}"

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -27,6 +27,17 @@ BLUE="\e[34m"
 RED="\e[31m"
 YELLOW="\e[33m"
 
+shasumCommand() {
+  if command -v sha256sum > /dev/null 2>&1; then
+    sha256sum "$@"
+  elif command -v shasum > /dev/null 2>&1; then
+    shasum --algorithm 256 "$@"
+  else 
+    echo "No checksum command!"
+    exit 1
+  fi
+}
+
 prefix="${default_prefix}"
 repository="${default_repository}"
 for arg in "$@"; do
@@ -76,18 +87,18 @@ platform_triple="${platform_triple_cpu}-${platform_triple_os}"
 case "${uname_s}" in
 Linux*)
   case $(cc -dumpmachine) in
-  *gnu)
-    platform_triple="${platform_triple}-gnu"
-    ;;
-  *musl)
-    platform_triple="${platform_triple}-musl"
-    ;;
-  *)
-    printf "%bUnable to determine libc type.\n" "${BLUE}"
-    printf "If you are using a musl libc based Linux, you'll need to use\n"
-    printf "%b--platform=musl%b when installing ponyc.%b\n" \
-      "${YELLOW}" "${BLUE}" "${DEFAULT}"
-    ;;
+    *gnu)
+      platform_triple="${platform_triple}-gnu"
+      ;;
+    *musl)
+      platform_triple="${platform_triple}-musl"
+      ;;
+    *)
+      printf "%bUnable to determine libc type.\n" "${BLUE}"
+      printf "If you are using a musl libc based Linux, you'll need to use\n"
+      printf "%b--platform=musl%b when installing ponyc.%b\n" \
+        "${YELLOW}" "${BLUE}" "${DEFAULT}"
+      ;;
   esac
   ;;
 esac
@@ -130,7 +141,7 @@ echo "downloading ${filename}"
 
 curl "${dl_url}" -o "${tmp_dir}/${filename}"
 
-dl_checksum="$(sha256sum "${tmp_dir}/${filename}" | awk '{ print $1 }')"
+dl_checksum="$(shasumCommand "${tmp_dir}/${filename}" | awk '{ print $1 }')"
 
 if [ "${dl_checksum}" != "${checksum}" ]; then
   printf "%bmchecksum mismatch:\n" "${RED}"
@@ -149,8 +160,18 @@ printf "%bponyup placed in %b${ponyup_root}/bin%b\n" \
   "${BLUE}" "${YELLOW}" "${DEFAULT}"
 
 if ! echo "$PATH" | grep -q "${ponyup_root}/bin"; then
-  printf "%bYou should add %b${ponyup_root}/bin%b to \$PATH:%b\n" \
-    "${BLUE}" "${YELLOW}" "${BLUE}" "${DEFAULT}"
-  printf "%bexport PATH=${ponyup_root}/bin:\$PATH%b\n" \
-    "${YELLOW}" "${DEFAULT}"
+  case "${SHELL}" in
+    *fish)
+      printf "%bYou should add %b${ponyup_root}/bin%b to \$PATH:%b\n" \
+        "${BLUE}" "${YELLOW}" "${BLUE}" "${DEFAULT}"
+      printf "%bset -g fish_user_paths ${ponyup_root}/bin \$fish_user_paths%b\n" \
+        "${YELLOW}" "${DEFAULT}"
+    ;;
+    *)
+      printf "%bYou should add %b${ponyup_root}/bin%b to \$PATH:%b\n" \
+        "${BLUE}" "${YELLOW}" "${BLUE}" "${DEFAULT}"
+      printf "%bexport PATH=${ponyup_root}/bin:\$PATH%b\n" \
+        "${YELLOW}" "${DEFAULT}"
+    ;;
+  esac
 fi

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -2,7 +2,6 @@
 
 set -o errexit
 set -o nounset
-set -o pipefail
 
 default_prefix="$HOME/.local/share"
 default_repository="releases"
@@ -34,7 +33,7 @@ shasumCommand() {
   elif command -v shasum > /dev/null 2>&1; then
     shasum --algorithm 256 "$@"
   else 
-    printf "%bNo checksum command found.%b\n" "${RED}" "${DEFAULT}" >&2
+    printf "%bNo checksum command found.%b\n" "${RED}" "${DEFAULT}"
     exit 1
   fi
 }


### PR DESCRIPTION
When I tried to install ponyup on my macOS machine, it was failing with this error:
```bash
sh: line 116: sha256sum: command not found
```

But  macOS Catalina comes with `shasum` utility, so I made a change to check if `sha256sum` is not available, then use `shasum`, otherwise just exit printing error.

Also, I use [fish shell](https://fish.sh) which has a slightly different syntax, so I added a custom message for fish.