### PR TITLE
Add libressl install instruction for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ This project is currently beta software.
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
 ```
 
+#### macOS
+
+You might need to install `libressl` as well.
+
+```bash
+brew install libressl
+```
+
 ### Install Pony
 
 Choose the latest release of the Pony compiler or the latest nightly build.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,7 @@ This project is currently beta software.
 
 ## Usage
 
-### Install ponyup
-
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
-```
+### Install dependencies
 
 #### macOS
 
@@ -22,6 +18,12 @@ You might need to install `libressl` as well.
 
 ```bash
 brew install libressl
+```
+
+### Install ponyup
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
 ```
 
 ### Install Pony

--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ This project is currently beta software.
 
 #### macOS
 
-You might need to install `libressl` as well.
-
 ```bash
 brew install libressl
 ```


### PR DESCRIPTION
`ponyup` requires `libressl` but it's not listed as a dependency. Not sure about Linux; that's why I only added a macOS section.