### PR TITLE
Fix broken alpine bootstrapping

### DIFF
--- a/.ci-dockerfiles/alpine-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/alpine-bootstrap-tester/Dockerfile
@@ -7,6 +7,7 @@ RUN apk update \
      build-base \
      curl \
      git \
+     libexecinfo \
      libexecinfo-static \
      libressl-dev \
      make

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,7 +45,7 @@ jobs:
     name: Test bootstrapping on Alpine
     runs-on: ubuntu-latest
     container:
-        image: ponylang/ponyup-ci-alpine-bootstrap-tester:20191228
+        image: ponylang/ponyup-ci-alpine-bootstrap-tester:20200418
     steps:
       - uses: actions/checkout@v1
       - name: Bootstrap test


### PR DESCRIPTION
Ponyc from alpine requires libexecinfo.