### PR TITLE
Use ponyup to install pony tools in macOS environments

### DIFF
--- a/.ci-scripts/macOS-install-pony-tools.bash
+++ b/.ci-scripts/macOS-install-pony-tools.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
+
+export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
+
+ponyup update ponyc release
+ponyup update pony-stable release

--- a/.ci-scripts/release/x86-64-apple-darwin-nightly.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-nightly.bash
@@ -9,10 +9,16 @@
 #
 # - bash
 # - cloudsmith-cli
+# - GNU coreutils
 # - GNU gzip
 # - GNU make
+# - libressl
 # - ponyc
+# - pony-stable
 # - GNU tar
+
+# add ponyup to PATH to get ponyc and pony-stable
+export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
 
 set -o errexit
 

--- a/.ci-scripts/release/x86-64-apple-darwin-release.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-release.bash
@@ -9,10 +9,16 @@
 #
 # - bash
 # - cloudsmith-cli
+# - GNU coreutils
 # - GNU gzip
 # - GNU make
+# - libressl
 # - ponyc
+# - pony stable
 # - GNU tar
+
+# add ponyup to PATH to get ponyc and pony-stable
+export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
 
 set -o errexit
 

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: brew install pony tools
-        run: brew install ponyc pony-stable
+      - name: install pony tools
+        run:  bash .ci-scripts/macOS-install-pony-tools.bash
       - name: brew install dependencies
         run: brew install coreutils libressl python
       - name: pip install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: brew install pony tools
-        run: brew install ponyc pony-stable
+      - name: install pony tools
+        run:  bash .ci-scripts/macOS-install-pony-tools.bash
       - name: brew install dependencies
         run: brew install coreutils libressl python
       - name: pip install dependencies


### PR DESCRIPTION
As of ponyc 0.34.0 we are no longer maintaining the homebrew ponyc
formula so it will get out of date. By using ponyup, we can stay
up-to-date with the latest releases.

Closes #102