### PR TITLE
Update bootstrap environments

### DIFF
--- a/.ci-dockerfiles/alpine-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/alpine-bootstrap-tester/Dockerfile
@@ -5,6 +5,7 @@ RUN apk update \
   && apk add --update \
      binutils-gold \
      build-base \
+     clang \
      curl \
      git \
      libexecinfo \

--- a/.ci-dockerfiles/fedora-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/fedora-bootstrap-tester/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:31
 RUN dnf update -y \
   && dnf upgrade -y \
   && dnf install -y \
-     gcc \
+     clang \
      curl \
      findutils \
      git \

--- a/.ci-dockerfiles/ubuntu-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/ubuntu-bootstrap-tester/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update \
-  && apt-get upgrade \
   && apt-get install -y \
-     gcc \
+     clang \
      curl \
      git \
      libssl-dev \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,29 +45,17 @@ jobs:
     name: Test bootstrapping on Alpine
     runs-on: ubuntu-latest
     container:
-        image: ponylang/ponyup-ci-alpine-bootstrap-tester:20200418
+        image: ponylang/ponyup-ci-alpine-bootstrap-tester:20200503
     steps:
       - uses: actions/checkout@v1
       - name: Bootstrap test
         run: .ci-scripts/test-bootstrap.sh
 
-  fedora-bootstrap:
-    name: Test bootstrapping on Fedora
-    runs-on: ubuntu-latest
-    container:
-        image: ponylang/ponyup-ci-fedora-bootstrap-tester:20200101
-    steps:
-      - uses: actions/checkout@v1
-      - name: Bootstrap test
-        run: |
-          export ssl=1.1.x
-          .ci-scripts/test-bootstrap.sh
-
   ubuntu-bootstrap:
     name: Test bootstrapping on Ubuntu
     runs-on: ubuntu-latest
     container:
-        image: ponylang/ponyup-ci-ubuntu-bootstrap-tester:20191228
+        image: ponylang/ponyup-ci-ubuntu-bootstrap-tester:20200503
     steps:
       - uses: actions/checkout@v1
       - name: Bootstrap test


### PR DESCRIPTION
We need clang to be installed with most recent ponyc as it uses
clang as the default linker.

Also, update to Ubuntu 20.04 as we no longer support 18.04