### PR TITLE
Allow corral to mangage it's dependency folders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ ssl ?= 0.9.0
 PONYC_FLAGS ?=
 
 BUILD_DIR ?= build/$(config)
-DEPS_DIRS ?= _corral _repos
 SRC_DIR ?= cmd
 binary := $(BUILD_DIR)/ponyup
 
@@ -75,7 +74,8 @@ GEN_FILES = $(patsubst %.pony.in, %.pony, $(GEN_FILES_IN))
 %.pony: %.pony.in VERSION
 	sed s/%%VERSION%%/$(version)/ $< > $@
 
-$(binary): $(GEN_FILES) $(SOURCE_FILES) | $(BUILD_DIR) $(DEPS_DIRS)
+$(binary): $(GEN_FILES) $(SOURCE_FILES) | $(BUILD_DIR)
+	corral fetch
 	corral run -- ponyc $(PONYC_FLAGS) $(LINKER) $(SRC_DIR) -o $(BUILD_DIR) -b ponyup
 
 install: $(binary)
@@ -86,16 +86,15 @@ install: $(binary)
 SOURCE_FILES := $(shell find cmd -name \*.pony)
 
 test: $(binary)
+	corral fetch
 	corral run -- ponyc $(PONYC_FLAGS) $(LINKER) test -o $(BUILD_DIR) -b test
 	$(BUILD_DIR)/test ${ponytest_args}
 
 clean:
-	rm -rf $(BUILD_DIR) $(DEPS_DIRS) $(GEN_FILES)
+	corral clean
+	rm -rf $(BUILD_DIR) $(GEN_FILES)
 
 all: test $(binary)
-
-$(DEPS_DIRS):
-	corral fetch
 
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)


### PR DESCRIPTION
The Makefile shouldn't have knowledge of where they are as they
are user configurable.