### PR TITLE
Select updated package by default

### DIFF
--- a/cmd/ponyup.pony
+++ b/cmd/ponyup.pony
@@ -154,11 +154,7 @@ actor Ponyup
   =>
     dl_path.remove()
     _lockfile.add_package(pkg)
-    if _lockfile.selection(pkg.name) is None then
-      select(pkg)
-    else
-      _lockfile.dispose()
-    end
+    select(pkg)
 
   be select(pkg: Package) =>
     try

--- a/test/main.pony
+++ b/test/main.pony
@@ -83,12 +83,12 @@ class _TestSelect is UnitTest
 
     let check =
       {()? =>
-        h.assert_true(link.canonical()?.path.contains(_ponyc_versions(0)?))
+        h.assert_true(link.canonical()?.path.contains(_ponyc_versions(1)?))
         _TestPonyup.exec(
-          h, "select", ["select"; "ponyc" ; _ponyc_versions(1)?],
+          h, "select", ["select"; "ponyc" ; _ponyc_versions(0)?],
           {()? =>
             h.assert_true(
-              link.canonical()?.path.contains(_ponyc_versions(1)?))
+              link.canonical()?.path.contains(_ponyc_versions(0)?))
             h.complete(true)
           } val)?
       } val


### PR DESCRIPTION
Select the new package version installed on update. Previously this
would only be done when installing a package for the first time.