### PR TITLE
Update homebrew before building nightly macOS release

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
+      - name: update homebrew
+        run: brew update
       - name: install pony tools
         run:  bash .ci-scripts/macOS-install-pony-tools.bash
       - name: brew install dependencies


### PR DESCRIPTION
We aren't building with the most recent libressl. I suspect it's
because we aren't updating before we run `brew install libressl` and
so we are getting an outdated version.

That could be wrong though. This is a test.