### PR TITLE
Don't use ponyup to install macOS pony tools

### DIFF
--- a/.ci-scripts/macOS-install-pony-tools.bash
+++ b/.ci-scripts/macOS-install-pony-tools.bash
@@ -7,12 +7,22 @@
 brew install libressl
 
 #
-# Install ponyup and other tools
+# Install ponyc the hard way
+# It will end up in /tmp/ponyc/ with the binary at /tmp/ponyc/bin/ponyc
 #
 
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh | sh
+cd /tmp
+mkdir ponyc
+curl -O 'https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-apple-darwin.tar.gz'
+tar -xvf ponyc-x86-64-apple-darwin.tar.gz -C ponyc --strip-components=1
 
-export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
+#
+# Install corral the hard way
+# It will end up in /tmp/corral/ with the binary at /tmp/corral/bin/corral
+#
 
-ponyup update ponyc release
-ponyup update corral release
+cd /tmp
+mkdir corral
+curl -O 'https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-apple-darwin.tar.gz'
+tar -xvf corral-x86-64-apple-darwin.tar.gz -C corral --strip-components=1
+

--- a/.ci-scripts/release/x86-64-apple-darwin-nightly.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-nightly.bash
@@ -17,8 +17,8 @@
 # - corral
 # - GNU tar
 
-# add ponyup to PATH to get ponyc and corral
-export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
+# add hard way installed ponyc, corral to our PATH
+export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
 
 set -o errexit
 

--- a/.ci-scripts/release/x86-64-apple-darwin-release.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-release.bash
@@ -17,9 +17,8 @@
 # - corral
 # - GNU tar
 
-# add ponyup to PATH to get ponyc and corral
-export PATH="$HOME/.local/share/ponyup/bin/:$PATH"
-
+# add hard way installed ponyc, corral to our PATH
+export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
 set -o errexit
 
 # Pull in shared configuration specific to this repo

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -72,7 +72,7 @@ jobs:
         run: bash .ci-scripts/macOS-install-pony-tools.bash
       - name: Test with the most recent ponyc release
         run: |
-          export PATH=$HOME/.local/share/ponyup/bin:$PATH
+          export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test
 
   macos-bootstrap:
@@ -80,7 +80,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
+      - name: update homebrew
+        run: brew update
       - name: brew install dependencies
-        run: brew install coreutils libressl
+        run:
+          brew install coreutils libressl
       - name: Bootstrap test
         run: .ci-scripts/test-bootstrap.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
+      - name: update homebrew
+        run: brew update
       - name: install pony tools
         run:  bash .ci-scripts/macOS-install-pony-tools.bash
       - name: brew install dependencies


### PR DESCRIPTION
When the libressl version changes, ponyup won't run, so we can't
build a new ponyup to adapt as the current ponyup can't run and
install the dependencies.

See #117