### PR TITLE
Prompt user for platform libc if unspecified by target triple

### DIFF
--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -94,12 +94,29 @@ Linux*)
     platform_triple="${platform_triple}-musl"
     ;;
   *)
-    platform_triple="${platform_triple}-gnu"
-    printf "%bUnable to determine libc type, defaulting to glibc.\n" "${BLUE}"
-    printf "If you are using a musl libc based Linux, you'll need to use\n"
-    printf "%b--platform=musl%b when installing ponyc.%b\n" \
-      "${YELLOW}" "${BLUE}" "${DEFAULT}"
-    ;;
+    while true; do
+      echo "Unable to determine libc type. Pease select one of the following:"
+      echo "1) glibc"
+      echo "2) musl"
+      echo "3) cancel"
+      printf "selection: "
+      read -r selection
+      case ${selection} in
+      1 | glibc)
+        platform_triple="${platform_triple}-gnu"
+        break
+        ;;
+      2 | musl)
+        platform_triple="${platform_triple}-musl"
+        break
+        ;;
+      3 | cancel)
+        exit 1
+        ;;
+      *)
+        ;;
+      esac
+    done
   esac
   ;;
 FreeBSD*)

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -94,7 +94,8 @@ Linux*)
     platform_triple="${platform_triple}-musl"
     ;;
   *)
-    printf "%bUnable to determine libc type.\n" "${BLUE}"
+    platform_triple="${platform_triple}-gnu"
+    printf "%bUnable to determine libc type, defaulting to glibc.\n" "${BLUE}"
     printf "If you are using a musl libc based Linux, you'll need to use\n"
     printf "%b--platform=musl%b when installing ponyc.%b\n" \
       "${YELLOW}" "${BLUE}" "${DEFAULT}"


### PR DESCRIPTION
Some Linux distributions, such as Fedora, do not include the libc in their target triple. For these cases we should prompt the user for the libc type now that ponyup no longer assumes glibc.