### PR TITLE
Upgrade to release-bot-action 0.2.1

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -8,14 +8,14 @@ jobs:
   announce-a-release:
     name: Announce a release
     runs-on: ubuntu-latest
-    container:
-      image: ponylang/shared-docker-ci-release:20191107
     steps:
       - uses: actions/checkout@v1
       - name: Announce
-        uses: ponylang/release-bot-action@0.1.0
+        uses: ponylang/release-bot-action@0.2.1
         with:
           step: announce-a-release
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
         env:
           ASSET_NAME: "ponyup"
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,14 +62,14 @@ jobs:
   trigger-release-announcement:
     name: Trigger release announcement
     runs-on: ubuntu-latest
-    container:
-      image: ponylang/shared-docker-ci-release:20191107
     needs: [x86-64-unknown-linux-release, x86-64-apple-darwin-release, build-release-docker-images, update-latest-release-tag]
     steps:
       - uses: actions/checkout@v1
       - name: Trigger
-        uses: ponylang/release-bot-action@0.1.0
+        uses: ponylang/release-bot-action@0.2.1
         with:
           step: trigger-release-announcement
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/start-a-release.yml
+++ b/.github/workflows/start-a-release.yml
@@ -8,13 +8,13 @@ jobs:
   start-a-release:
     name: Start a release
     runs-on: ubuntu-latest
-    container:
-      image: ponylang/shared-docker-ci-release:20191107
     steps:
       - uses: actions/checkout@v1
       - name: Start
-        uses: ponylang/release-bot-action@0.1.0
+        uses: ponylang/release-bot-action@0.2.1
         with:
           step: start-a-release
+          git_user_name: "Ponylang Main Bot"
+          git_user_email: "ponylang.main@gmail.com"
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
We move from 0.1.0 to 0.2.1. Our reason for moving is to
get support for release notes put together by the
release-notes-bot-action.