### PR TITLE
improve regex match of json field in init script

### DIFF
--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -27,10 +27,8 @@ exit_usage() {
 json_field() {
   json=$1
   key=$2
-  echo "${json}" |
-    awk -F"\"${key}\":" '{print $2}' |
-    awk '{print $1}' |
-    sed 's/[",]//g'
+  value_pattern=': *"\([^"]*\)"'
+  echo "${json}" | sed "s/.*\"${key}\"${value_pattern}.*/\\1/"
 }
 
 DEFAULT="\e[39m"


### PR DESCRIPTION
Modifications to the Cloudsmith API have resulted in mangled version identifiers for the initial ponyup install. This has resulted in the `"tags": {"version": ["latest"]},` being matched as the version, resulting in the following output for `ponyup show`:
```
ponyup-release-[latest]}-x86_64-linux
```
The updated regex should be sufficient to prevent such an issue from occurring in the future without requiring `jq` to be available on the user's system.