### PR TITLE
improve some error messages

### DIFF
--- a/cmd/main.pony
+++ b/cmd/main.pony
@@ -87,6 +87,11 @@ actor Main is PonyupNotify
         with f = OpenFile(ponyup_dir.join(".platform")?) as File do
           platform = f.lines().next()? .> lstrip() .> rstrip()
         end
+      else
+        log(
+          Err,
+          "unable to determine platform (" + ponyup_dir.path + "/.platform)")
+        return
       end
     end
     log(Extra, "platform: " + platform)

--- a/cmd/ponyup.pony
+++ b/cmd/ponyup.pony
@@ -108,7 +108,7 @@ actor Ponyup
         _notify.log(Err, "invalid path: " + _root.path + "/" + pkg'.string())
         return
       end
-    _notify.log(Info, "pulling " + version)
+    _notify.log(Info, "pulling " + pkg'.string())
     _notify.log(Extra, "download url: " + download_url)
     _notify.log(Extra, "install path: " + install_path.path)
 


### PR DESCRIPTION
The error messages resulting from a missing `.platform` file were not immediately obvious, which slowed down debugging an unrelated issue.