### PR TITLE
Fix ponyup-init on freebsd

### DIFF
--- a/.release-notes/156.md
+++ b/.release-notes/156.md
@@ -1,0 +1,4 @@
+## Fix ponyup-init on FreeBSD
+
+There was a small typo in a variable name that broke
+running ponyup-init on FreeBSD.

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -72,7 +72,7 @@ Darwin*)
   ;;
 FreeBSD*)
   download_os="unknown-freebsd"
-  platform-triple_os="unknown-freebsd"
+  platform_triple_os="unknown-freebsd"
   ;;
 Linux*)
   download_os="unknown-linux"


### PR DESCRIPTION
There was a small typo that made running `ponyup-init.sh` on FreeBSD impossible