### PR TITLE
sh != always bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ brew install libressl
 ### Install ponyup
 
 ```bash
-sh -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)"
+bash -c "$(curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/ponylang/ponyup/latest-release/ponyup-init.sh)"
 ```
 
 ### Install Pony


### PR DESCRIPTION
Quick fix for colour codes not displaying correctly when sh != bash -- script runs fine in Bash on Void Linux with Bash 5.1.4