### PR TITLE
Don't prompt for libc type when not on Linux

### DIFF
--- a/.release-notes/179.md
+++ b/.release-notes/179.md
@@ -1,0 +1,3 @@
+## Fix confusing and seemingly broken installation on MacOS
+
+MacOS installation looked like it was failing because it prompted for a libc version to install forcing the user to select "cancel" as the option. Ponyup was actually installed correctly, but the end user had no way of knowing.

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -191,31 +191,34 @@ if ! echo "$PATH" | grep -q "${ponyup_root}/bin"; then
   esac
 fi
 
-if [ "${platform_triple_distro}" = "" ]; then
-  while true; do
-    echo "Unable to determine libc type. Pease select one of the following:"
-    echo "1) glibc"
-    echo "2) musl"
-    echo "3) cancel"
-    printf "selection: "
-    read -r selection
-    case ${selection} in
-    1 | glibc)
-      platform_triple_distro="gnu"
-      break
-      ;;
-    2 | musl)
-      platform_triple_distro="musl"
-      break
-      ;;
-    3 | cancel)
-      exit 1
-      ;;
-    *) ;;
-    esac
-  done
-  platform_triple="${platform_triple}-${platform_triple_distro}"
-fi
+case "${uname_s}" in
+Linux*)
+  if [ "${platform_triple_distro}" = "" ]; then
+    while true; do
+      echo "Unable to determine libc type. Please select one of the following:"
+      echo "1) glibc"
+      echo "2) musl"
+      echo "3) cancel"
+      printf "selection: "
+      read -r selection
+      case ${selection} in
+      1 | glibc)
+        platform_triple_distro="gnu"
+        break
+        ;;
+      2 | musl)
+        platform_triple_distro="musl"
+        break
+        ;;
+      3 | cancel)
+        exit 1
+        ;;
+      *) ;;
+      esac
+    done
+    platform_triple="${platform_triple}-${platform_triple_distro}"
+  fi
+esac
 
 printf "%bsetting default platform to %b${platform_triple}%b\n" \
   "${BLUE}" "${YELLOW}" "${DEFAULT}"


### PR DESCRIPTION
Currently, Darwin users are prompted for the libc type. This shouldn't
be happening. Only Linux users should get prompted.

Closes #178