### PR TITLE
Run with ponynoblock

### DIFF
--- a/cmd/main.pony
+++ b/cmd/main.pony
@@ -206,6 +206,9 @@ actor Main is PonyupNotify
         if not _boring then ANSI.reset() else "" end
       ].values())
 
+  fun @runtime_override_defaults(rto: RuntimeOptions) =>
+    rto.ponynoblock = true
+
 primitive Info
 primitive Extra
 primitive Err


### PR DESCRIPTION
We don't need the cycle detector. Running without it lessens our chances
of hitting any cycle-detector related bugs.