### PR TITLE
Update Linux builder image

### DIFF
--- a/.github/workflows/breakage-against-linux-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-linux-ponyc-latest.yml
@@ -9,7 +9,7 @@ jobs:
     name: Verify main against ponyc main on Linux
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:latest
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.1.2:latest
     steps:
       - uses: actions/checkout@v1
       - name: Test with a recent ponyc from main

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -9,7 +9,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.1.2:release
     steps:
       - uses: actions/checkout@v1
       - name: Build and upload

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,7 @@ jobs:
     name: Verify PR builds on Linux with most recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.1.2:release
     steps:
       - uses: actions/checkout@v1
       - name: Test with the most recent ponyc release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:release
+      image: ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.1.2:release
     steps:
       - uses: actions/checkout@v1
       - name: Build and upload

--- a/.release-notes/182.md
+++ b/.release-notes/182.md
@@ -1,0 +1,3 @@
+## Fix segfault in prebuilt Linux ponyup releases
+
+There was a bug in the Pony runtime related to opening sockets that could cause a segfault. The bug was fixed a few months ago, but our Linux ponyup releases were still being built with an older version (aka still with the bug) of the Pony runtime due to a stale build environment.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-ssl:release AS build
+FROM ponylang/shared-docker-ci-x86-64-unknown-linux-builder-with-libressl-3.1.2:release AS build
 
 WORKDIR /src/ponyup
 


### PR DESCRIPTION
The previous image had been deprecated and wasn't being updated anymore so,
we weren't picking up ponyc changes- including bug fixes.