### PR TITLE
Update to match breaking API change in the pony standard library (RFC 69)

### DIFF
--- a/cmd/ponyup.pony
+++ b/cmd/ponyup.pony
@@ -70,7 +70,7 @@ actor Ponyup
     _notify.log(Info, "updating " + pkg.string())
     let src_url = Cloudsmith.repo_url(pkg.channel)
     _notify.log(Info, "syncing updates from " + src_url)
-    let query_string = src_url + Cloudsmith.query(pkg)
+    let query_string = recover val src_url + Cloudsmith.query(pkg) end
     _notify.log(Extra, "query url: " + query_string)
 
     _http_get(
@@ -406,7 +406,7 @@ actor ShowPackages
         try
           let target = recover val platform.split("-") end
           let pkg = Packages.from_fragments(name, channel, "latest", target)?
-          let query_str = Cloudsmith.repo_url(channel) + Cloudsmith.query(pkg)
+          let query_str = recover val Cloudsmith.repo_url(channel) + Cloudsmith.query(pkg) end
           _notify.log(Extra, "query url: " + query_str)
           _http_get(
             query_str,

--- a/corral.json
+++ b/corral.json
@@ -6,11 +6,11 @@
     },
     {
       "locator": "github.com/ponylang/appdirs.git",
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "locator": "github.com/ponylang/http.git",
-      "version": "0.4.0"
+      "version": "0.4.1"
     }
   ],
   "info": {


### PR DESCRIPTION
Also update http dependencies to pick up its changes related to the same
RFC.

This change is backwards compatible with ponyc 0.40.0

---

The tests against nightly were [failing](https://github.com/ponylang/ponyup/runs/2514096262) due do this.