### PR TITLE
Fixes Issue #191

### DIFF
--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -31,10 +31,10 @@ json_field() {
   echo "${json}" | sed "s/.*\"${key}\"${value_pattern}.*/\\1/"
 }
 
-DEFAULT="\e[39m"
-BLUE="\e[34m"
-RED="\e[31m"
-YELLOW="\e[33m"
+DEFAULT=$'\e[39m'
+BLUE=$'\e[34m'
+RED=$'\e[31m'
+YELLOW=$'\e[33m'
 
 prefix="${default_prefix}"
 repository="${default_repository}"

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -31,10 +31,10 @@ json_field() {
   echo "${json}" | sed "s/.*\"${key}\"${value_pattern}.*/\\1/"
 }
 
-DEFAULT=$'\e[39m'
-BLUE=$'\e[34m'
-RED=$'\e[31m'
-YELLOW=$'\e[33m'
+DEFAULT="\033[39m"
+BLUE="\033[34m"
+RED="\033[31m"
+YELLOW="\033[33m"
 
 prefix="${default_prefix}"
 repository="${default_repository}"


### PR DESCRIPTION
    Fixes Issue #191
    
    The root of this bug is where the expansion of \e to the
    binary escape character happens.  In the case before this PR
    it's being done by printf.
    
    FreeBSD does not have \e in its printf implementation.
    Linux does.
    
    The fix I am suggesting is to get the shell to do the expansion
    instead.  By changing the string definitions from using double
    quotes to dollar single-quote format - the shell will do the
    expansion.
