### PR TITLE
Better versions on Windows

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -72,7 +72,7 @@ jobs:
           .\make.ps1 -Command build;
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
-          $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/nightlies build\ponyup-x86-64-pc-windows-msvc.zip
+          cloudsmith push raw --version nightly --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/nightlies build\ponyup-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       - name: Send alert on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           .\make.ps1 -Command build;
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
-          $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/releases build\ponyup-x86-64-pc-windows-msvc.zip
+          cloudsmith push raw --version release --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/releases build\ponyup-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 

--- a/make.ps1
+++ b/make.ps1
@@ -45,9 +45,11 @@ else
   throw "Invalid -Config path '$Config'; must be one of (Debug, Release)."
 }
 
-if (($Version -eq "") -and (Test-Path -Path "$rootDir\VERSION"))
+switch ($Version)
 {
-  $Version = (Get-Content "$rootDir\VERSION") + "-" + (& git 'rev-parse' '--short' '--verify' 'HEAD^')
+  "release" { $Version = Get-Content "$rootDir\VERSION" }
+  "nightly" { $Version = "nightly" + (Get-Date).ToString("yyyyMMdd") }
+  default { $Version = (Get-Content "$rootDir\VERSION") + "-" + (& git rev-parse --short --verify HEAD) }
 }
 
 $ponyArgs = "--define openssl_0.9.0"


### PR DESCRIPTION
- Use git HEAD rather than HEAD^ (not sure why Windows was using HEAD^)
- Set versions for release and nightly builds to conform to ponyc conventions.