### PR TITLE
Fix failing Windows build uploads

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -72,7 +72,7 @@ jobs:
           .\make.ps1 -Command build;
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
-          cloudsmith push raw --version nightly --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/nightlies build\ponyup-x86-64-pc-windows-msvc.zip
+          $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version  --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/nightlies build\ponyup-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
       - name: Send alert on failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           .\make.ps1 -Command build;
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
-          cloudsmith push raw --version release --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/releases build\ponyup-x86-64-pc-windows-msvc.zip
+          $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/releases build\ponyup-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
 


### PR DESCRIPTION
Only 1 release or nightly build would work because...

All releases have the same name and they also were using the same
version. Either `nightly` or `release`.

This PR updates so that each release and nightly has a unique version.
The unique version matches what Cloudsmith is expecting.