### PR TITLE
Update crypto dependency

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -2,7 +2,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/crypto.git",
-      "version": "1.1.5"
+      "version": "1.1.6"
     },
     {
       "locator": "github.com/ponylang/appdirs.git",


### PR DESCRIPTION
The previous version 1.1.5 didn't have the correct libssl paths
when on Arm64 MacOS. The new version does thereby eliminating a
link warning.