### PR TITLE
Update Alpine version used for CI to 3.16

### DIFF
--- a/.ci-dockerfiles/alpine-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/alpine-bootstrap-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 
 RUN apk add --update --no-cache \
      binutils-gold \


### PR DESCRIPTION
Previously we were using Alpine 3.12 which is no longer supported.