### PR TITLE
Update Alpine version used for CI to 3.16 (#229)

### DIFF
--- a/.ci-dockerfiles/alpine-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/alpine-bootstrap-tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.16
 
 RUN apk add --update --no-cache \
      binutils-gold \

--- a/.release-notes/alpine-316.md
+++ b/.release-notes/alpine-316.md
@@ -1,0 +1,5 @@
+## Update Dockerfile to Alpine 3.16
+
+The ponyup Docker container has been updated from being based on Alpine 3.12 to Alpine 3.16. This shouldn't be a breaking change for pretty much anyone, but might be if you are using the ponyup image as a base for other images and some package you rely on was removed from Alpine 3.16.
+
+Alpine 3.12 is no longer supported. Alpine 3.16 is supported through 2024.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /src/ponyup
 
 RUN make arch=x86-64 static=true linker=bfd config=release
 
-FROM alpine:3.12
+FROM alpine:3.16
 
 COPY --from=build /src/ponyup/build/release/ponyup /usr/local/bin/ponyup
 


### PR DESCRIPTION
Previously we were using Alpine 3.12 which is no longer supported.