### PR TITLE
Fixed ponyup-init.sh crash when specifying --prefix

### DIFF
--- a/.release-notes/236.md
+++ b/.release-notes/236.md
@@ -1,0 +1,4 @@
+## Fixed ponyup-init.sh crash when specifying --prefix
+
+When running `ponyup-init.sh` with the `--prefix` parameter, the script would crash because the `ponyup` invocation at the end of the script wasn't running with the same prefix. This minor change fixes that by also running `ponyup` with the `--prefix` parameter.`
+

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -227,4 +227,4 @@ esac
 printf "%bsetting default platform to %b${platform_triple}%b\n" \
   "${BLUE}" "${YELLOW}" "${DEFAULT}"
 
-"${ponyup_root}/bin/ponyup" default "${platform_triple}"
+"${ponyup_root}/bin/ponyup" --prefix="${prefix}" default "${platform_triple}"


### PR DESCRIPTION
I downloaded the `ponyup-init.sh` script and ran it like so:

```shell
./ponyup-init.sh --prefix=/opt
```

The script crashes at the end with the following error message:

```
error: unable to determine platform (/root/.local/share/ponyup/.platform)
```

This change seems to fix the problem.