### PR TITLE
Add ponyc 0.52.3 to select test matrix

### DIFF
--- a/test/main.pony
+++ b/test/main.pony
@@ -79,7 +79,7 @@ class _TestSync is UnitTest
 
 class _TestSelect is UnitTest
   let _ponyc_versions: Array[String] val =
-    ["release-0.52.2"; "release-0.52.2"]
+    ["release-0.52.2"; "release-0.52.3"]
 
   fun name(): String =>
     "select"


### PR DESCRIPTION
Previously we only had 0.52.2 as it was the only available on all platforms (due to the recent switch from FreeBSD 13.0 to 13.1).