### PR TITLE
Don't use `stable` as part of bootstrapping tests

### DIFF
--- a/.ci-scripts/test-bootstrap.sh
+++ b/.ci-scripts/test-bootstrap.sh
@@ -14,7 +14,6 @@ fi
 ponyup update ponyc nightly
 ponyup update changelog-tool nightly
 ponyup update corral nightly
-ponyup update stable nightly
 
 ${MAKE} clean
 ${MAKE} ssl=${SSL}


### PR DESCRIPTION
It has been deprecated for a long time.