### PR TITLE
Add support for building with OpenSSL 3

### DIFF
--- a/.ci-dockerfiles/ubuntu22.04-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/ubuntu22.04-bootstrap-tester/Dockerfile
@@ -1,0 +1,11 @@
+FROM ubuntu:22.04
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     ca-certificates \
+     clang \
+     curl \
+     git \
+     libssl-dev \
+     make \
+  && rm -rf /var/lib/apt/lists/*

--- a/.ci-dockerfiles/ubuntu22.04-bootstrap-tester/build-and-push.bash
+++ b/.ci-dockerfiles/ubuntu22.04-bootstrap-tester/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to DockerHub when you run this ***
+#
+
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+
+docker build --pull -t "ponylang/ponyup-ci-ubuntu22.04-bootstrap-tester:${TODAY}" \
+  "${DOCKERFILE_DIR}"
+docker push "ponylang/ponyup-ci-ubuntu22.04-bootstrap-tester:${TODAY}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,7 +57,7 @@ jobs:
         run: SSL=0.9.0 .ci-scripts/test-bootstrap.sh
 
   ubuntu20_04-bootstrap:
-    name: Test bootstrapping on Ubuntu
+    name: Test bootstrapping on Ubuntu 20.04
     runs-on: ubuntu-latest
     container:
         image: ponylang/ponyup-ci-ubuntu20.04-bootstrap-tester:20210414
@@ -65,6 +65,16 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bootstrap test
         run: .ci-scripts/test-bootstrap.sh
+
+  ubuntu22_04-bootstrap:
+    name: Test bootstrapping on Ubuntu 22.04
+    runs-on: ubuntu-latest
+    container:
+        image: ponylang/ponyup-ci-ubuntu22.04-bootstrap-tester:20230103
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bootstrap test
+        run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
 
   ubuntu18_04-bootstrap:
     name: Test bootstrapping on Ubuntu 18.04

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,9 @@ ifeq ($(config),debug)
 	PONYC_FLAGS += --debug
 endif
 
-ifeq ($(ssl), 1.1.x)
+ifeq ($(ssl), 3.0.x)
+	PONYC_FLAGS += -Dopenssl_3.0.x
+else ifeq ($(ssl), 1.1.x)
 	PONYC_FLAGS += -Dopenssl_1.1.x
 else ifeq ($(ssl), 0.9.0)
 	PONYC_FLAGS += -Dopenssl_0.9.0

--- a/corral.json
+++ b/corral.json
@@ -2,7 +2,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/crypto.git",
-      "version": "1.2.0"
+      "version": "1.2.1"
     },
     {
       "locator": "github.com/ponylang/appdirs.git",

--- a/corral.json
+++ b/corral.json
@@ -2,7 +2,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/crypto.git",
-      "version": "1.1.6"
+      "version": "1.2.0"
     },
     {
       "locator": "github.com/ponylang/appdirs.git",
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/http.git",
-      "version": "0.5.2"
+      "version": "0.5.3"
     }
   ],
   "info": {


### PR DESCRIPTION
This includes a builder for Ubuntu 22.04 that features OpenSSL 3 to verify that it is all working, plus tests to verify that we are correctly set up to build with OpenSSL 3 support on.