### PR TITLE
Never use the "generic gnu" ponyc package

### DIFF
--- a/.ci-dockerfiles/ubuntu18.04-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/ubuntu18.04-bootstrap-tester/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get update \
      curl \
      git \
      libssl-dev \
+     lsb-core \
      make \
   && rm -rf /var/lib/apt/lists/*

--- a/.ci-dockerfiles/ubuntu20.04-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/ubuntu20.04-bootstrap-tester/Dockerfile
@@ -1,5 +1,9 @@
 FROM ubuntu:20.04
 
+# Keep annoying tzdata prompt from coming up
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBCONF_NONINTERACTIVE_SEEN true
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
      ca-certificates \
@@ -7,5 +11,6 @@ RUN apt-get update \
      curl \
      git \
      libssl-dev \
+     lsb-core \
      make \
   && rm -rf /var/lib/apt/lists/*

--- a/.ci-dockerfiles/ubuntu20.04-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/ubuntu20.04-bootstrap-tester/Dockerfile
@@ -14,3 +14,5 @@ RUN apt-get update \
      lsb-core \
      make \
   && rm -rf /var/lib/apt/lists/*
+
+RUN git config --global --add safe.directory /__w/ponyup/ponyup

--- a/.ci-dockerfiles/ubuntu22.04-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/ubuntu22.04-bootstrap-tester/Dockerfile
@@ -7,5 +7,6 @@ RUN apt-get update \
      curl \
      git \
      libssl-dev \
+     lsb-core \
      make \
   && rm -rf /var/lib/apt/lists/*

--- a/.ci-dockerfiles/ubuntu22.04-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/ubuntu22.04-bootstrap-tester/Dockerfile
@@ -10,3 +10,5 @@ RUN apt-get update \
      lsb-core \
      make \
   && rm -rf /var/lib/apt/lists/*
+
+RUN git config --global --add safe.directory /__w/ponyup/ponyup

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,7 +60,7 @@ jobs:
     name: Test bootstrapping on Ubuntu 20.04
     runs-on: ubuntu-latest
     container:
-        image: ponylang/ponyup-ci-ubuntu20.04-bootstrap-tester:20210414
+        image: ponylang/ponyup-ci-ubuntu20.04-bootstrap-tester:20230120
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap test
@@ -70,7 +70,7 @@ jobs:
     name: Test bootstrapping on Ubuntu 22.04
     runs-on: ubuntu-latest
     container:
-        image: ponylang/ponyup-ci-ubuntu22.04-bootstrap-tester:20230103
+        image: ponylang/ponyup-ci-ubuntu22.04-bootstrap-tester:20230120
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap test
@@ -80,7 +80,7 @@ jobs:
     name: Test bootstrapping on Ubuntu 18.04
     runs-on: ubuntu-latest
     container:
-        image: ponylang/ponyup-ci-ubuntu18.04-bootstrap-tester:20200901
+        image: ponylang/ponyup-ci-ubuntu18.04-bootstrap-tester:20230120
     steps:
       - uses: actions/checkout@v2
       - name: Bootstrap test

--- a/.release-notes/245.md
+++ b/.release-notes/245.md
@@ -1,0 +1,5 @@
+## Stop installing "generic gnu" ponyc builds
+
+Previously, on glibc based Linux distributions, the default setup of ponyup would install the "generic gnu" builds of ponyc. These "generic builds" only work on Linux distributions that are library compatible with the build environment. This use of "generic gnu" made it easy to install a ponyc that wouldn't work on the users platform even if we have ponyc builds for said distribution.
+
+We've stopped using the "generic gnu" builds and instead, on glibc Linux distributions, are using `lsb_release -d` to determine the distribution and if we support the distribution, set up ponyup to install ponyc builds for the distribution in question. If we don't support the distribution or recognize the output of `lsb_release`, an error message is displayed.

--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ The `ponyup show` command will display the installed package versions with the s
 $ ponyup show
 stable-nightly-20191116 *
 stable-nightly-20191115
-ponyc-release-0.33.0-gnu *
-ponyc-nightly-20191116-gnu
-ponyc-nightly-20191115-gnu
+ponyc-release-0.33.0-musl *
+ponyc-nightly-20191116-musl
+ponyc-nightly-20191115-musl
 corral-nightly-20191115 * -- corral-nightly-20191116
 changelog-tool-nightly-20191116
 changelog-tool-nightly-20191115 *
@@ -91,9 +91,9 @@ The `show` command also has an optional `package` argument to show only the inst
 
 ```console
 $ ponyup show ponyc
-ponyc-release-0.33.0-gnu *
-ponyc-nightly-20191116-gnu
-ponyc-nightly-20191115-gnu
+ponyc-release-0.33.0-musl *
+ponyc-nightly-20191116-musl
+ponyc-nightly-20191115-musl
 ```
 
 ### Select an installed package as default
@@ -102,19 +102,19 @@ The `select` command can switch which installed package version to set as defaul
 
 ```console
 $ ponyup show ponyc
-ponyc-release-0.33.0-gnu *
-ponyc-nightly-20191116-gnu
-ponyc-nightly-20191115-gnu
+ponyc-release-0.33.0-ubuntu18.04 *
+ponyc-nightly-20191116-ubuntu18.04
+ponyc-nightly-20191115-ubuntu18.04
 $ ponyc --version
 0.33.0-98c36095 [release]
 compiled with: llvm 7.0.1 -- cc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0
 Defaults: pic=true
 $ ponyup select ponyc nightly-20191116
-selecting ponyc-nightly-20191116-gnu as default for ponyc
+selecting ponyc-nightly-20191116-ubuntu18.04 as default for ponyc
 $ ponyup show ponyc
-ponyc-release-0.33.0-gnu
-ponyc-nightly-20191116-gnu *
-ponyc-nightly-20191115-gnu
+ponyc-release-0.33.0-ubuntu18.04
+ponyc-nightly-20191116-ubuntu18.04 *
+ponyc-nightly-20191115-ubuntu18.04
 $ ponyc --version
 nightly-20191116 [release]
 compiled with: llvm 7.1.0 -- cc (Ubuntu 7.4.0-1ubuntu1~18.04.1) 7.4.0
@@ -123,7 +123,7 @@ Defaults: pic=true
 
 ### Platform options
 
-Ponyup is able to detect the CPU architecture and operating system of the platform on which it is running. The `--platform` option is used to override any field in the platform identifier (e.g. `x86_64-linux-gnu`).
+Ponyup is able to detect the CPU architecture and operating system of the platform on which it is running. The `--platform` option is used to override any field in the platform identifier (e.g. `x86_64-linux-ubuntu22.04`).
 
 ### Common Issues
 
@@ -133,4 +133,4 @@ Ponyup is able to detect the CPU architecture and operating system of the platfo
   error: unexpected selection: ponyc-release-x86_64-unknown-linux
   ```
 
-  This is likely caused by a target triple that does not specify the libc ABI for the platform, as detected by `cc -dumpmachine`. The solution is to manually set the platform identifier using `ponyup default <platform>`, where `<platform>` is a platform identifier such as `x86_64-linux-gnu`.
+  This is likely caused by a target triple that does not specify the libc ABI for the platform, as detected by `cc -dumpmachine`. The solution is to manually set the platform identifier using `ponyup default <platform>`, where `<platform>` is a platform identifier such as `x86_64-linux-ubuntu22.04`.

--- a/cmd/cli.pony
+++ b/cmd/cli.pony
@@ -47,7 +47,7 @@ primitive CLI
           "Install or update a package",
           [ OptionSpec.string(
               "platform",
-              "Specify platform (such as x86_64-linux-gnu)",
+              "Specify platform (such as x86_64-linux-ubuntu22.04)",
               None,
               "")
           ],
@@ -59,7 +59,7 @@ primitive CLI
           "Select the default version for a package",
           [ OptionSpec.string(
               "platform",
-              "Specify platform (such as x86_64-linux-gnu)",
+              "Specify platform (such as x86_64-linux-ubuntu22.04)",
               None,
               "")
           ],
@@ -68,7 +68,7 @@ primitive CLI
           ])?
         CommandSpec.leaf(
           "default",
-          "Set the default platform (such as x86_64-linux-gnu)",
+          "Set the default platform (such as x86_64-linux-ubuntu22.04)",
           [],
           [ ArgSpec.string("platform")
           ])?

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -95,7 +95,36 @@ case "${uname_s}" in
 Linux*)
   case $(cc -dumpmachine) in
   *gnu)
-    platform_triple_distro="gnu"
+    case "$(lsb_release -d)" in
+    *"Ubuntu 22.04"*)
+      platform_triple_distro="ubuntu_22.04"
+      ;;
+    *"Ubuntu 20.04"*)
+      platform_triple_distro="ubuntu_20.04"
+      ;;
+    *"Ubuntu 18.04"*)
+      platform_triple_distro="ubuntu_18.04"
+      ;;
+    *"Linux Mint 21"*)
+      platform_triple_distro="ubuntu_22.04"
+      ;;
+    *"Linux Mint 20"*)
+      platform_triple_distro="ubuntu_20.04"
+      ;;
+    *"Linux Mint 19"*)
+      platform_triple_distro="ubuntu_18.04"
+      ;;
+    *"Pop!_OS 22.04"*)
+      platform_triple_distro="ubuntu_22.04"
+      ;;
+    *"Pop!_OS 20.04"*)
+      platform_triple_distro="ubuntu_20.04"
+      ;;
+    *"Pop!_OS 18.04"*)
+      platform_triple_distro="ubuntu_18.04"
+      ;;
+    *) ;;
+    esac
     ;;
   *musl)
     platform_triple_distro="musl"
@@ -198,29 +227,14 @@ fi
 case "${uname_s}" in
 Linux*)
   if [ "${platform_triple_distro}" = "" ]; then
-    while true; do
-      echo "Unable to determine libc type. Please select one of the following:"
-      echo "1) glibc"
-      echo "2) musl"
-      echo "3) cancel"
-      printf "selection: "
-      read -r selection
-      case ${selection} in
-      1 | glibc)
-        platform_triple_distro="gnu"
-        break
-        ;;
-      2 | musl)
-        platform_triple_distro="musl"
-        break
-        ;;
-      3 | cancel)
-        exit 1
-        ;;
-      *) ;;
-      esac
-    done
-    platform_triple="${platform_triple}-${platform_triple_distro}"
+    echo "Unable to determine Linux platform type."
+    echo "Please see to manually https://github.com/ponylang/ponyc/blob/main/INSTALL.md#linux to manually set your platform."
+
+    # set prefix even if we don't know the default platform to set
+    "${ponyup_root}/bin/ponyup" --prefix="${prefix}"
+
+    # we don't consider this exit to be an error
+    exit 0
   fi
 esac
 

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -228,7 +228,7 @@ case "${uname_s}" in
 Linux*)
   if [ "${platform_triple_distro}" = "" ]; then
     echo "Unable to determine Linux platform type."
-    echo "Please see to manually https://github.com/ponylang/ponyc/blob/main/INSTALL.md#linux to manually set your platform."
+    echo "Please see https://github.com/ponylang/ponyc/blob/main/INSTALL.md#linux to manually set your platform."
 
     # set prefix even if we don't know the default platform to set
     "${ponyup_root}/bin/ponyup" --prefix="${prefix}"

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -227,8 +227,8 @@ fi
 case "${uname_s}" in
 Linux*)
   if [ "${platform_triple_distro}" = "" ]; then
-    echo "Unable to determine Linux platform type."
-    echo "Please see https://github.com/ponylang/ponyc/blob/main/INSTALL.md#linux to manually set your platform."
+    printf "%bUnable to determine Linux platform type.%b\n" "${YELLOW}" "${DEFAULT}"
+    printf "%bPlease see https://github.com/ponylang/ponyc/blob/main/INSTALL.md#linux to manually set your platform.%b\n" "${YELLOW}" "${DEFAULT}"
 
     # set prefix even if we don't know the default platform to set
     "${ponyup_root}/bin/ponyup" --prefix="${prefix}"

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -97,31 +97,31 @@ Linux*)
   *gnu)
     case "$(lsb_release -d)" in
     *"Ubuntu 22.04"*)
-      platform_triple_distro="ubuntu_22.04"
+      platform_triple_distro="ubuntu22.04"
       ;;
     *"Ubuntu 20.04"*)
-      platform_triple_distro="ubuntu_20.04"
+      platform_triple_distro="ubuntu20.04"
       ;;
     *"Ubuntu 18.04"*)
-      platform_triple_distro="ubuntu_18.04"
+      platform_triple_distro="ubuntu18.04"
       ;;
     *"Linux Mint 21"*)
-      platform_triple_distro="ubuntu_22.04"
+      platform_triple_distro="ubuntu22.04"
       ;;
     *"Linux Mint 20"*)
-      platform_triple_distro="ubuntu_20.04"
+      platform_triple_distro="ubuntu20.04"
       ;;
     *"Linux Mint 19"*)
-      platform_triple_distro="ubuntu_18.04"
+      platform_triple_distro="ubuntu18.04"
       ;;
     *"Pop!_OS 22.04"*)
-      platform_triple_distro="ubuntu_22.04"
+      platform_triple_distro="ubuntu22.04"
       ;;
     *"Pop!_OS 20.04"*)
-      platform_triple_distro="ubuntu_20.04"
+      platform_triple_distro="ubuntu20.04"
       ;;
     *"Pop!_OS 18.04"*)
-      platform_triple_distro="ubuntu_18.04"
+      platform_triple_distro="ubuntu18.04"
       ;;
     *) ;;
     esac

--- a/test/main.pony
+++ b/test/main.pony
@@ -29,10 +29,10 @@ class _TestParsePlatform is UnitTest
 
     let tests =
       [ as (String, ((CPU, OS, Distro) | None)):
-        ("ponyc-?-?-x86_64-unknown-linux-gnu", (AMD64, Linux, "gnu"))
-        ("ponyc-?-?-x64-linux-gnu", (AMD64, Linux, "gnu"))
+        ("ponyc-?-?-x86_64-unknown-linux-ubuntu22.04", (AMD64, Linux, "ubuntu22.04"))
+        ("ponyc-?-?-x64-linux-ubuntu22.04", (AMD64, Linux, "ubuntu22.04"))
         ("ponyc-x86_64-pc-linux-ubuntu18.04", (AMD64, Linux, "ubuntu18.04"))
-        ("?-?-?-amd64-linux-gnu", (AMD64, Linux, None))
+        ("?-?-?-amd64-linux-ubuntu22.04", (AMD64, Linux, None))
         ("ponyc-?-?-x86_64-alpine-linux-musl", (AMD64, Linux, "musl"))
         ("?-?-?-x86_64-alpine-linux-musl", (AMD64, Linux, None))
         ("ponyc-?-?-x86_64-apple-darwin", (AMD64, Darwin, None))


### PR DESCRIPTION
The "generic gnu" package is not actually generic. It is a glibc version that is built on "some glibc using Linux" and will work if it is installed on a Linux that is compatible at a library level with the system that we built the "generic gnu" package on.

Quite some time ago, Theo and I (who made the initial decision to include a "generic gnu") realized that the "generic gnu" idea was "a very bad idea".

There are a couple large problems with this approach:

1- anyone using ponyup on glibc distro that isn't compatible with our "generic gnu" platform will by default have things installed that will not work. That's a bad user experience.

2- in order to not fall horribly behind, from time to time, we need to "rev" the environment used to build "generic gnu" in. For us that has meant changing the Ubuntu version periodically. That then means that people who had an environment that worked will do an update and install a ponyc that doesn't work because it is for a different set of libraries. That's a bad user experience as well.

This PR drops "generic gnu" from being used by the ponyup installer and it avoids it being set as a target platform. Instead when the installer detects that it is being run on a glibc based Linux, it will attempt to identify the distro being used and if we support it, it will use the builds we do for that distro. In the case of "distros built on distros" like Linux Mint being built on Ubuntu, it will set the platform to the builds for the appropriate "base distro". If we are unable to determine the distro or the distro isn't supported, an error message is displayed that directs them to the Linux install instructions in the ponyc repo.

I will be doing a corresponding PR to ponyc to update the Linux section of INSTALL.md to account for the changes from this PR. Additionally, once this is merged, we can stop building the "generic gnu" package which I will also open a PR for.