### PR TITLE
Turn on macOS x86 unit tests

### DIFF
--- a/.github/workflows/breakage-against-macOS-x86-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-macOS-x86-ponyc-latest.yml
@@ -12,12 +12,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: install pony tools
         run: bash .ci-scripts/macOS-x86-install-pony-tools.bash nightly
-      # we can't turn this on until we are able to pass the tests
-      # that requires a couple of macos on intel ponyc releases
-      # - name: Test with the most recent ponyc release
-      #   run: |
-      #     export PATH=/tmp/corral/bin/:/tmp/ponyc/bin/:$PATH
-      #     make test
+      - name: Test with the most recent ponyc release
+        run: |
+          export PATH=/tmp/corral/bin/:/tmp/ponyc/bin/:$PATH
+          make test
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -80,19 +80,17 @@ jobs:
       - name: Bootstrap test
         run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
 
-  # This won't pass until we have a few ponyc versions that have macos on intel
-  # and we update the versions we test with. This is off for now.
-  # macos:
-  #   name: Verify PR builds on x86-64 macOS with most recent ponyc release
-  #   runs-on: macos-13
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - name: install pony tools
-  #       run: bash .ci-scripts/macOS-x86-install-pony-tools.bash release
-  #     - name: Test with the most recent ponyc release
-  #       run: |
-  #         export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
-  #         make test
+  macos:
+    name: Verify PR builds on x86-64 macOS with most recent ponyc release
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v3
+      - name: install pony tools
+        run: bash .ci-scripts/macOS-x86-install-pony-tools.bash release
+      - name: Test with the most recent ponyc release
+        run: |
+          export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
+          make test
 
   x86-64-macos-bootstrap:
     name: Test bootstrapping on macOS x86-64


### PR DESCRIPTION
They couldn't pass previously but we have two releases now that will allow us to pass the select unit test.