### PR TITLE
docs: remove misleading reference to Windows from Unix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ These commands will download the chosen version of ponyc and install it to `$HOM
 
 On Unix:
 
-By default, ponyup will create its root directory in `$HOME/.local/share` ( on Windows). This prefix can be set manually with the `--prefix` (or `-p`) option. All packages selected as default will be symbolically linked into `${prefix}/ponyup/bin`. So, by default, `ponyup update release ponyc` will install `ponyc` to `$HOME/.local/share/ponyup/bin/ponyc`.
+By default, ponyup will create its root directory in `$HOME/.local/share`. This prefix can be set manually with the `--prefix` (or `-p`) option. All packages selected as default will be symbolically linked into `${prefix}/ponyup/bin`. So, by default, `ponyup update release ponyc` will install `ponyc` to `$HOME/.local/share/ponyup/bin/ponyc`.
 
 On Windows:
 


### PR DESCRIPTION
There is now a separate subsection for Windows instructions, so I presume the `(on Windows)` comment in the Unix portion of `Set install prefix` is a leftover.