### PR TITLE
Use release version of ponyc on MacOS for Apple Silicon

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: Test with the most recent ponyc release
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools
-        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
         run: brew install coreutils
       - name: pip install dependencies


### PR DESCRIPTION
We were using nightlies as there was no recent ponyc release for arm64 MacOS until 0.58.2 was released today.