### PR TITLE
Add Fedora 42 support

### DIFF
--- a/.ci-dockerfiles/fedora42-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/fedora42-bootstrap-tester/Dockerfile
@@ -1,0 +1,12 @@
+FROM fedora:42
+
+RUN dnf install -y binutils-gold \
+  clang \
+  git \
+  lsb-release \
+  openssl-devel \
+ && dnf -y autoremove \
+ && dnf -y clean all \
+ && rm -rf /var/cache/dnf*
+
+RUN git config --global --add safe.directory /__w/ponyup/ponyup

--- a/.ci-dockerfiles/fedora42-bootstrap-tester/build-and-push.bash
+++ b/.ci-dockerfiles/fedora42-bootstrap-tester/build-and-push.bash
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+DOCKER_TAG="ghcr.io/ponylang/ponyup-ci-fedora42-bootstrap-tester:${TODAY}"
+
+docker build --pull -t "${DOCKER_TAG}" "${DOCKERFILE_DIR}"
+docker push "${DOCKER_TAG}"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -135,6 +135,16 @@ jobs:
       - name: Bootstrap test
         run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
 
+  fedora42-bootstrap:
+    name: Fedora 42 bootstrap
+    runs-on: ubuntu-latest
+    container:
+        image: ghcr.io/ponylang/ponyup-ci-fedora42-bootstrap-tester:latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Bootstrap test
+        run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
+
   ubuntu22_04-bootstrap:
     name: Ubuntu 22.04 bootstrap
     runs-on: ubuntu-latest

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -118,6 +118,10 @@ Linux*)
     *"Fedora Linux 41"*)
       platform_triple_distro="fedora41"
       ;;
+    *"Fedora Linux 42"*)
+      # Fedora 42 support
+      platform_triple_distro="fedora42"
+      ;;
     *) ;;
     esac
     ;;


### PR DESCRIPTION
**Fedora 42 Support**

* Added `.ci-dockerfiles/fedora42-bootstrap-tester/Dockerfile`
* Added `.ci-dockerfiles/fedora42-bootstrap-tester/build-and-push.bash`
* Updated `.github/workflows/pr.yml` to include a new `fedora42-bootstrap` job
* Modified `ponyup-init.sh` to detect Fedora 42 as a valid platform.

> I hope this request is fine and I didn't do something dumb. If I did just tell me pls and also tell me if I should do anything better or in another way next time. Thanks :)