### PR TITLE
Update MacOS Intel runners to MacOS 15

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -2,3 +2,4 @@
 self-hosted-runner:
   labels:
     - windows-11-arm
+    - macos-15-intel

--- a/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   vs-ponyc-main-macos:
     name: Verify main against ponyc main on x86-64 macOS
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -135,7 +135,7 @@ jobs:
 
   x86-64-apple-darwin-nightly:
     name: Build and upload x86-64-apple-darwin-nightly to Cloudsmith
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -167,7 +167,7 @@ jobs:
 
   x86-64-macos-bootstrap:
     name: x86-64 MacOS bootstrap
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install dependencies
@@ -217,7 +217,7 @@ jobs:
 
   x86-64-macos:
     name: x86-64 MacOS tests
-    runs-on: macos-13
+    runs-on: macos-15-intel
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
   x86-64-apple-darwin-release:
     name: Build and upload x86-64-apple-darwin to Cloudsmith
-    runs-on: macos-13
+    runs-on: macos-15-intel
     needs:
       - pre-artefact-creation
     steps:


### PR DESCRIPTION
The MacOS 13 runners are going away soon. GitHub will provide new MacOS 15 Intel runners until August 2027.