### PR TITLE
Add support for installing pony-doc

### DIFF
--- a/.release-notes/pony-doc.md
+++ b/.release-notes/pony-doc.md
@@ -1,0 +1,4 @@
+## Add support for installing pony-doc
+
+We've recently introduced a [documentation generation tool for Pony](https://www.ponylang.io/use/documentation/). We've updated ponyup to correctly install it when you select a ponyc distribution that includes `pony-doc`.
+

--- a/cmd/packages.pony
+++ b/cmd/packages.pony
@@ -20,6 +20,7 @@ primitive PonycApplication is Application
     Binary("ponyc")
     Binary("pony-lsp", false)
     Binary("pony-lint", false)
+    Binary("pony-doc", false)
   ]
 
 primitive PonyupApplication is Application


### PR DESCRIPTION
Mirror the pony-lint support added in PR #347 — declare pony-doc as an optional binary in PonycApplication so ponyup installs it when present in a ponyc distribution.