### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/cmd/cli.pony
+++ b/cmd/cli.pony
@@ -8,7 +8,7 @@ primitive CLI
     : (Command | (U8, String))
   =>
     try
-      match CommandParser(_spec(default_prefix)?).parse(args, envs)
+      match \exhaustive\ CommandParser(_spec(default_prefix)?).parse(args, envs)
       | let c: Command => c
       | let h: CommandHelp => (0, h.help_string())
       | let e: SyntaxError => (1, e.string())

--- a/cmd/cloudsmith.pony
+++ b/cmd/cloudsmith.pony
@@ -11,7 +11,7 @@ primitive Cloudsmith
 
   fun repo_url(repo': String): String =>
     let repo_name =
-      match consume repo'
+      match \exhaustive\ consume repo'
       | "nightly" => "nightlies"
       | "release" => "releases"
       | let s: String => s

--- a/cmd/http_handlers.pony
+++ b/cmd/http_handlers.pony
@@ -50,7 +50,7 @@ class QueryHandler is HTTPHandler
     end
 
   fun ref chunk(data: (String | Array[U8] val)) =>
-    match data
+    match \exhaustive\ data
     | let s: String => _buf.append(s)
     | let bs: Array[U8] val => _buf.append(String.from_array(bs))
     end

--- a/cmd/main.pony
+++ b/cmd/main.pony
@@ -26,7 +26,7 @@ actor Main is PonyupNotify
     let default_prefix: String val =
       _default_root.substring(0, -"/ponyup".size().isize())
     let command =
-      match recover val CLI.parse(_env.args, _env.vars, default_prefix) end
+      match \exhaustive\ recover val CLI.parse(_env.args, _env.vars, default_prefix) end
       | let c: Command val => c
       | (let exit_code: U8, let msg: String) =>
         if exit_code == 0 then
@@ -180,7 +180,7 @@ actor Main is PonyupNotify
     end
 
   be log(level: LogLevel, msg: String) =>
-    match level
+    match \exhaustive\ level
     | Info | Extra =>
       if (level is Info) or _verbose then
         if level is Extra then

--- a/cmd/packages.pony
+++ b/cmd/packages.pony
@@ -131,7 +131,7 @@ primitive Packages
     if Platform.linux() then distro end
 
   fun platform_requires_distro(os: OS): Bool =>
-    match os
+    match \exhaustive\ os
     | Linux => true
     | Darwin => false
     | Windows => false

--- a/test/main.pony
+++ b/test/main.pony
@@ -48,7 +48,7 @@ class _TestParsePlatform is UnitTest
       ]
     for (input, expected) in tests.values() do
       h.log("input: " + input)
-      match expected
+      match \exhaustive\ expected
       | (let cpu: CPU, let os: OS, let distro: Distro) =>
         let pkg = Packages.from_string(input)?
         h.log("  => " + pkg.platform().string())


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.