### PR TITLE
Update macOS runners to macos-26

### DIFF
--- a/.github/workflows/breakage-against-macos-arm64-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-macos-arm64-ponyc-latest.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   vs-ponyc-main-macos:
     name: Verify main against ponyc main on arm64 macOS
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools

--- a/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   vs-ponyc-main-macos:
     name: Verify main against ponyc main on x86-64 macOS
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -135,7 +135,7 @@ jobs:
 
   x86-64-apple-darwin-nightly:
     name: Build and upload x86-64-apple-darwin-nightly to Cloudsmith
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools
@@ -162,7 +162,7 @@ jobs:
 
   arm64-apple-darwin-nightly:
     name: Build and upload arm64-apple-darwin-nightly to Cloudsmith
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -168,7 +168,7 @@ jobs:
 
   arm64-macos-bootstrap:
     name: arm64 MacOS bootstrap
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install dependencies
@@ -183,7 +183,7 @@ jobs:
 
   x86-64-macos-bootstrap:
     name: x86-64 MacOS bootstrap
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Install dependencies
@@ -233,7 +233,7 @@ jobs:
 
   x86-64-macos:
     name: x86-64 MacOS tests
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools
@@ -245,7 +245,7 @@ jobs:
 
   arm64-macos:
     name: arm64 MacOS tests
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
 
   x86-64-apple-darwin-release:
     name: Build and upload x86-64-apple-darwin to Cloudsmith
-    runs-on: macos-15-intel
+    runs-on: macos-26-intel
     needs:
       - pre-artefact-creation
     steps:
@@ -92,7 +92,7 @@ jobs:
 
   arm64-apple-darwin-release:
     name: Build and upload arm64-apple-darwin to Cloudsmith
-    runs-on: macos-15
+    runs-on: macos-26
     needs:
       - pre-artefact-creation
     steps:


### PR DESCRIPTION
macOS 26 runners are now generally available for GitHub Actions.

Update macOS runners from macos-15 to macos-26 and macos-15-intel to macos-26-intel across all workflows.