### PR TITLE
Update actions/checkout from v4.1.1 to v6.0.2

### DIFF
--- a/.github/workflows/announce-a-release.yml
+++ b/.github/workflows/announce-a-release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/breakage-against-linux-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-linux-ponyc-latest.yml
@@ -15,7 +15,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Test with a recent ponyc from main
         run: make test config=debug
       - name: Send alert on failure

--- a/.github/workflows/breakage-against-macos-arm64-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-macos-arm64-ponyc-latest.yml
@@ -12,7 +12,7 @@ jobs:
     name: Verify main against ponyc main on arm64 macOS
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
       - name: Test with the most recent ponyc release

--- a/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-macos-x86-ponyc-latest.yml
@@ -12,7 +12,7 @@ jobs:
     name: Verify main against ponyc main on x86-64 macOS
     runs-on: macos-26-intel
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
       - name: Test with the most recent ponyc release

--- a/.github/workflows/lint-action-workflows.yml
+++ b/.github/workflows/lint-action-workflows.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Check workflow files
         uses: docker://ghcr.io/ponylang/shared-docker-ci-actionlint:20260311
         with:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Pull Docker image
         run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
       - name: Build and upload
@@ -52,7 +52,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: bash .ci-scripts/release/x86-64-unknown-linux-nightly.bash
         env:
@@ -73,7 +73,7 @@ jobs:
     name: Build and upload x86-64-pc-windows-msvc-nightly to Cloudsmith
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
@@ -105,7 +105,7 @@ jobs:
     name: Build and upload arm64-pc-windows-msvc-nightly to Cloudsmith
     runs-on: windows-11-arm
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
@@ -137,7 +137,7 @@ jobs:
     name: Build and upload x86-64-apple-darwin-nightly to Cloudsmith
     runs-on: macos-26-intel
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
       - name: brew install dependencies
@@ -164,7 +164,7 @@ jobs:
     name: Build and upload arm64-apple-darwin-nightly to Cloudsmith
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies

--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint bash, docker, markdown, and yaml
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Lint codebase
         uses: docker://github/super-linter:v3.8.3
         env:
@@ -29,7 +29,7 @@ jobs:
     name: Verify CHANGELOG is valid
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Verify CHANGELOG
         uses: docker://ghcr.io/ponylang/changelog-tool:release
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -102,7 +102,7 @@ jobs:
     container:
         image: ghcr.io/ponylang/ponyup-ci-ubuntu24.04-bootstrap-tester:20250603
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Bootstrap test
         run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
 
@@ -112,7 +112,7 @@ jobs:
     container:
         image: ghcr.io/ponylang/ponyup-ci-alpine3.20-bootstrap-tester:20250603
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Bootstrap test
         run: SSL=0.9.0 .ci-scripts/test-bootstrap.sh
 
@@ -122,7 +122,7 @@ jobs:
     container:
         image: ghcr.io/ponylang/ponyup-ci-alpine3.21-bootstrap-tester:20250603
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Bootstrap test
         run: SSL=0.9.0 .ci-scripts/test-bootstrap.sh
 
@@ -132,7 +132,7 @@ jobs:
     container:
         image: ghcr.io/ponylang/ponyup-ci-alpine3.22-bootstrap-tester:20251022
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Bootstrap test
         run: SSL=0.9.0 .ci-scripts/test-bootstrap.sh
 
@@ -142,7 +142,7 @@ jobs:
     container:
         image: ghcr.io/ponylang/ponyup-ci-alpine3.23-bootstrap-tester:20260201
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Bootstrap test
         run: SSL=0.9.0 .ci-scripts/test-bootstrap.sh
 
@@ -152,7 +152,7 @@ jobs:
     container:
         image: ghcr.io/ponylang/ponyup-ci-ubuntu24.04-bootstrap-tester:20250603
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Bootstrap test
         run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
 
@@ -162,7 +162,7 @@ jobs:
     container:
         image: ghcr.io/ponylang/ponyup-ci-ubuntu22.04-bootstrap-tester:20230830
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Bootstrap test
         run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
 
@@ -170,7 +170,7 @@ jobs:
     name: arm64 MacOS bootstrap
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Install dependencies
         # libressl gets installed but is returning a non-zero exit code,
         # so we have to soldier on through the stupidity
@@ -185,7 +185,7 @@ jobs:
     name: x86-64 MacOS bootstrap
     runs-on: macos-26-intel
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Install dependencies
         # libressl gets installed but is returning a non-zero exit code,
         # so we have to soldier on through the stupidity
@@ -210,7 +210,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Pull Docker image
         run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
       - name: Test with most recent ponyc release
@@ -227,7 +227,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Test with the most recent ponyc release
         run: make test
 
@@ -235,7 +235,7 @@ jobs:
     name: x86-64 MacOS tests
     runs-on: macos-26-intel
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: bash .ci-scripts/macos-x86-install-pony-tools.bash release
       - name: Test with the most recent ponyc release
@@ -247,7 +247,7 @@ jobs:
     name: arm64 MacOS tests
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: Test with the most recent ponyc release
@@ -259,7 +259,7 @@ jobs:
     name: x86-64 Windows tests
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc release
         run: |
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
@@ -275,7 +275,7 @@ jobs:
     name: arm64 Windows tests
     runs-on: windows-11-arm
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Test with most recent ponyc release
         run: |
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;

--- a/.github/workflows/prepare-for-a-release.yml
+++ b/.github/workflows/prepare-for-a-release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout main
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}
@@ -45,7 +45,7 @@ jobs:
       - pre-artefact-creation
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v6.0.2
       - name: Pull Docker image
         run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
       - name: Build and upload
@@ -66,7 +66,7 @@ jobs:
     container:
       image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: bash .ci-scripts/release/x86-64-unknown-linux-release.bash
         env:
@@ -78,7 +78,7 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
       - name: brew install dependencies
@@ -96,7 +96,7 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
@@ -114,7 +114,7 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
@@ -137,7 +137,7 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
@@ -160,7 +160,7 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
       - name: Tag
         run: |
           git tag --force latest-release
@@ -180,7 +180,7 @@ jobs:
       - arm64-apple-darwin-release
       - update-latest-release-tag
     steps:
-      - uses: actions/checkout@v4.1.1
+      - uses: actions/checkout@v6.0.2
         with:
           ref: "main"
           token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Node 20 reaches EOL in April 2026 and GitHub will force Node 24 after June 2, 2026. v6 already uses Node 24 natively.