### PR TITLE
Port from ponylang/json to stdlib json (json-ng)

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
       - name: Build and upload
         run: |
           docker run --rm \
@@ -32,7 +32,7 @@ jobs:
             -w /root/project \
             -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly \
             bash .ci-scripts/release/arm64-unknown-linux-nightly.bash
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -50,7 +50,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly to Cloudsmith
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
@@ -77,9 +77,9 @@ jobs:
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch;
@@ -109,9 +109,9 @@ jobs:
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch;
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
+        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: brew install coreutils
       - name: pip install dependencies
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
+        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: brew install coreutils
       - name: pip install dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -212,23 +212,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
-      - name: Test with most recent ponyc release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
+      - name: Test with most recent ponyc nightly
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/root/project \
             -w /root/project \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly \
             make test
 
   x86-64-linux:
     name: x86-64 Linux tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with the most recent ponyc release
+      - name: Test with the most recent ponyc nightly
         run: make test
 
   x86-64-macos:
@@ -237,8 +237,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macos-x86-install-pony-tools.bash release
-      - name: Test with the most recent ponyc release
+        run: bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
+      - name: Test with the most recent ponyc nightly
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test
@@ -249,8 +249,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
-      - name: Test with the most recent ponyc release
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+      - name: Test with the most recent ponyc nightly
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test
@@ -260,11 +260,11 @@ jobs:
     runs-on: windows-2025
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch 2>&1
@@ -276,11 +276,11 @@ jobs:
     runs-on: windows-11-arm
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch 2>&1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
       - name: Build and upload
         run: |
           docker run --rm \
@@ -55,7 +55,7 @@ jobs:
             -w /root/project \
             -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly \
             bash .ci-scripts/release/arm64-unknown-linux-release.bash
 
   x86-64-unknown-linux-release:
@@ -64,7 +64,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
+        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: brew install coreutils
       - name: pip install dependencies
@@ -98,7 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
+        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: brew install coreutils
       - name: pip install dependencies
@@ -118,9 +118,9 @@ jobs:
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch;
@@ -141,9 +141,9 @@ jobs:
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch;

--- a/cmd/http_handlers.pony
+++ b/cmd/http_handlers.pony
@@ -57,12 +57,11 @@ class QueryHandler is HTTPHandler
 
   fun ref finished() =>
     _notify.log(Extra, "received response of size " + _buf.size().string())
-    let json_doc = recover trn JsonDoc end
     let result = recover Array[JsonObject val] end
-    try
-      json_doc.parse(_buf = recover String end)?
-      for v in ((consume val json_doc).data as JsonArray val).data.values() do
-        result.push(v as JsonObject val)
+    match JsonParser.parse(_buf = recover String end)
+    | let arr: JsonArray =>
+      for v in arr.values() do
+        try result.push(v as JsonObject) end
       end
     end
     _cb(consume result)

--- a/cmd/ponyup.pony
+++ b/cmd/ponyup.pony
@@ -79,9 +79,9 @@ actor Ponyup
     (let version, let checksum, let download_url) =
       try
         res(0)?
-        ( res(0)?.data("version")? as String
-        , res(0)?.data("checksum_sha512")? as String
-        , res(0)?.data("cdn_url")? as String )
+        ( res(0)?("version")? as String
+        , res(0)?("checksum_sha512")? as String
+        , res(0)?("cdn_url")? as String )
       else
         _notify.log(Err, "".join(
           [ "requested package, "; pkg; ", was not found"
@@ -639,7 +639,7 @@ actor ShowPackages
                 _notify,
                 {(res) =>
                   try
-                    let version = (consume res)(0)?.data("version")? as String
+                    let version = (consume res)(0)?("version")? as String
                     self.append(pkg.update_version(version))
                   end
                 })
@@ -750,8 +750,8 @@ actor FindPackages
         if result_ch != ch then continue end
         for entry in entries.values() do
           try
-            let version = entry.data("version")? as String
-            let filename = entry.data("filename")? as String
+            let version = entry("version")? as String
+            let filename = entry("filename")? as String
             rows.push((_application_name, ch, version, filename))
           end
         end

--- a/corral.json
+++ b/corral.json
@@ -11,10 +11,6 @@
     {
       "locator": "github.com/ponylang/http.git",
       "version": "0.6.4"
-    },
-    {
-      "locator": "github.com/ponylang/json.git",
-      "version": "0.2.0"
     }
   ],
   "info": {

--- a/test/main.pony
+++ b/test/main.pony
@@ -385,8 +385,8 @@ actor _SyncTester is PonyupNotify
   be add_packages(pkg: Package, res: Array[JsonObject val] iso) =>
     for obj in (consume res).values() do
       try
-        let file = obj.data("filename")? as String
-        _pkgs.push(pkg.update_version(obj.data("version")? as String))
+        let file = obj("filename")? as String
+        _pkgs.push(pkg.update_version(obj("version")? as String))
       end
     end
     run()


### PR DESCRIPTION
Drop the external ponylang/json dependency in favor of the json package now in the ponyc stdlib (json-ng). The API migration: `JsonDoc`-based parsing becomes `JsonParser.parse()` with pattern matching, and `JsonObject.data("key")?` becomes `JsonObject("key")?`.

Since json-ng is only in nightly ponyc, all CI workflows that build ponyup are switched from ponyc release to nightly — Docker image tags, macOS install-pony-tools script arguments, and Windows download URLs. Cloudsmith push destinations for release and nightly artifacts are unchanged.