### PR TITLE
Use prebuilt LibreSSL binaries on Windows

### DIFF
--- a/.ci-scripts/windows-install-libressl.ps1
+++ b/.ci-scripts/windows-install-libressl.ps1
@@ -1,0 +1,20 @@
+$version = "3.9.1"
+
+$arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+if ($arch -ieq "X64") { $zipArch = "x64" }
+elseif ($arch -ieq "Arm64") { $zipArch = "ARM64" }
+else { throw "Unsupported architecture: $arch" }
+
+$zipName = "libressl_v${version}_windows_${zipArch}.zip"
+$url = "https://github.com/libressl/portable/releases/download/v${version}/${zipName}"
+
+$tempDir = Join-Path $env:TEMP "libressl"
+if (-not (Test-Path $tempDir)) { New-Item -ItemType Directory -Path $tempDir | Out-Null }
+
+Invoke-WebRequest $url -OutFile "$tempDir\$zipName"
+Expand-Archive -Force -Path "$tempDir\$zipName" -DestinationPath "$tempDir\libressl"
+
+$repoRoot = Split-Path $PSScriptRoot
+Copy-Item -Force "$tempDir\libressl\lib\ssl.lib" "$repoRoot\ssl.lib"
+Copy-Item -Force "$tempDir\libressl\lib\crypto.lib" "$repoRoot\crypto.lib"
+Copy-Item -Force "$tempDir\libressl\lib\tls.lib" "$repoRoot\tls.lib"

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -80,18 +80,18 @@ jobs:
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
-      - name: cache SSL libs
-        id: restore-libs
+      - name: Cache LibreSSL libs
+        id: cache-libressl
         uses: actions/cache@v5.0.3
         with:
           path: |
             ssl.lib
             crypto.lib
             tls.lib
-          key: rootlibs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('make.ps1') }}
-      - name: build SSL libs
-        if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: .\make.ps1 -Command libs  2>&1;
+          key: libressl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ci-scripts/windows-install-libressl.ps1') }}
+      - name: Install LibreSSL
+        if: steps.cache-libressl.outputs.cache-hit != 'true'
+        run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
@@ -126,18 +126,18 @@ jobs:
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
-      - name: cache SSL libs
-        id: restore-libs
+      - name: Cache LibreSSL libs
+        id: cache-libressl
         uses: actions/cache@v5.0.3
         with:
           path: |
             ssl.lib
             crypto.lib
             tls.lib
-          key: rootlibs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('make.ps1') }}
-      - name: build SSL libs
-        if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: .\make.ps1 -Command libs  2>&1;
+          key: libressl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ci-scripts/windows-install-libressl.ps1') }}
+      - name: Install LibreSSL
+        if: steps.cache-libressl.outputs.cache-hit != 'true'
+        run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -266,18 +266,18 @@ jobs:
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Path C:\corral.zip -DestinationPath C:\ponyc;
-      - name: cache SSL libs
-        id: restore-libs
+      - name: Cache LibreSSL libs
+        id: cache-libressl
         uses: actions/cache@v5.0.3
         with:
           path: |
             ssl.lib
             crypto.lib
             tls.lib
-          key: rootlibs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('make.ps1') }}
-      - name: build SSL libs
-        if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: .\make.ps1 -Command libs  2>&1;
+          key: libressl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ci-scripts/windows-install-libressl.ps1') }}
+      - name: Install LibreSSL
+        if: steps.cache-libressl.outputs.cache-hit != 'true'
+        run: .ci-scripts\windows-install-libressl.ps1
       - name: Test with most recent ponyc release
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
@@ -296,18 +296,18 @@ jobs:
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
-      - name: cache SSL libs
-        id: restore-libs
+      - name: Cache LibreSSL libs
+        id: cache-libressl
         uses: actions/cache@v5.0.3
         with:
           path: |
             ssl.lib
             crypto.lib
             tls.lib
-          key: rootlibs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('make.ps1') }}
-      - name: build SSL libs
-        if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: .\make.ps1 -Command libs  2>&1;
+          key: libressl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ci-scripts/windows-install-libressl.ps1') }}
+      - name: Install LibreSSL
+        if: steps.cache-libressl.outputs.cache-hit != 'true'
+        run: .ci-scripts\windows-install-libressl.ps1
       - name: Test with most recent ponyc release
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,18 +121,18 @@ jobs:
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
-      - name: cache SSL libs
-        id: restore-libs
+      - name: Cache LibreSSL libs
+        id: cache-libressl
         uses: actions/cache@v5.0.3
         with:
           path: |
             ssl.lib
             crypto.lib
             tls.lib
-          key: rootlibs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('make.ps1') }}
-      - name: build SSL libs
-        if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: .\make.ps1 -Command libs  2>&1;
+          key: libressl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ci-scripts/windows-install-libressl.ps1') }}
+      - name: Install LibreSSL
+        if: steps.cache-libressl.outputs.cache-hit != 'true'
+        run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli
@@ -158,18 +158,18 @@ jobs:
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
           Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
-      - name: cache SSL libs
-        id: restore-libs
+      - name: Cache LibreSSL libs
+        id: cache-libressl
         uses: actions/cache@v5.0.3
         with:
           path: |
             ssl.lib
             crypto.lib
             tls.lib
-          key: rootlibs-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('make.ps1') }}
-      - name: build SSL libs
-        if: steps.restore-libs.outputs.cache-hit != 'true'
-        run: .\make.ps1 -Command libs  2>&1;
+          key: libressl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ci-scripts/windows-install-libressl.ps1') }}
+      - name: Install LibreSSL
+        if: steps.cache-libressl.outputs.cache-hit != 'true'
+        run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
           python.exe -m pip install --upgrade cloudsmith-cli

--- a/.release-notes/use-prebuilt-libressl.md
+++ b/.release-notes/use-prebuilt-libressl.md
@@ -1,0 +1,3 @@
+## Use prebuilt LibreSSL binaries on Windows
+
+The `libs` command has been removed from `make.ps1`. CI now downloads prebuilt LibreSSL static libraries directly from the [LibreSSL GitHub releases](https://github.com/libressl/portable/releases) instead of building from source. Windows users who were using `make.ps1 -Command libs` to build LibreSSL locally can download prebuilt binaries from the same location. Prebuilt binaries are available for x86-64 and ARM64.

--- a/make.ps1
+++ b/make.ps1
@@ -1,5 +1,5 @@
 Param(
-  [Parameter(Position=0, HelpMessage="The action to take (fetch, libs, build, test, buildtest, install, package, clean).")]
+  [Parameter(Position=0, HelpMessage="The action to take (fetch, build, test, buildtest, install, package, clean).")]
   [string]
   $Command = 'build',
 
@@ -39,7 +39,6 @@ $testPath = "../test" # The path of the tests package relative to $targetPath.
 $isLibrary = $false
 
 $rootDir = Split-Path $script:MyInvocation.MyCommand.Path
-$libsDir = Join-Path -Path $rootDir -ChildPath "build/libs"
 $srcDir = Join-Path -Path $rootDir -ChildPath $targetPath
 
 if ($Config -ieq "Release")
@@ -91,45 +90,6 @@ if (($Command -ne "clean") -and (Test-Path -Path "$rootDir\VERSION"))
       Write-Host "$templateFile -> $ponyFile"
       ((Get-Content -Path $templateFile) -replace '%%VERSION%%', $Version) | Set-Content -Path $ponyFile
     }
-  }
-}
-
-function BuildLibs
-{
-  # When upgrading, change $libreSsl, $libreSslLib, and the copied libs below
-  $libreSsl = "libressl-3.9.1"
-
-  if (-not ((Test-Path "$rootDir/crypto.lib") -and (Test-Path "$rootDir/ssl.lib")))
-  {
-    $libreSslSrc = Join-Path -Path $libsDir -ChildPath $libreSsl
-
-    if (-not (Test-Path $libreSslSrc))
-    {
-      $libreSslTgz = "$libreSsl.tar.gz"
-      $libreSslTgzTgt = Join-Path -Path $libsDir -ChildPath $libreSslTgz
-      if (-not (Test-Path $libreSslTgzTgt)) { Invoke-WebRequest -TimeoutSec 300 -Uri "https://cdn.openbsd.org/pub/OpenBSD/LibreSSL/$libreSslTgz" -OutFile $libreSslTgzTgt }
-      tar -xvzf "$libreSslTgzTgt" -C "$libsDir"
-      if ($LastExitCode -ne 0) { throw "Error downloading and extracting $libreSslTgz" }
-    }
-
-    $libreSslLib = Join-Path -Path $libsDir -ChildPath "lib/ssl-53.lib"
-
-    if (-not (Test-Path $libreSslLib))
-    {
-      Push-Location $libreSslSrc
-      (Get-Content "$libreSslSrc\CMakeLists.txt").replace('add_definitions(-Dinline=__inline)', "add_definitions(-Dinline=__inline)`nadd_definitions(-DPATH_MAX=255)") | Set-Content "$libreSslSrc\CMakeLists.txt"
-      if ($Arch -ieq 'arm64') { $cmakeArch = 'ARM64' } else { $cmakeArch = 'x64' }
-      cmake.exe $libreSslSrc -Thost=x64 -A $cmakeArch -DCMAKE_INSTALL_PREFIX="$libsDir" -DCMAKE_BUILD_TYPE="Release"
-      if ($LastExitCode -ne 0) { Pop-Location; throw "Error configuring $libreSsl" }
-      cmake.exe --build . --target install --config Release
-      if ($LastExitCode -ne 0) { Pop-Location; throw "Error building $libreSsl" }
-      Pop-Location
-    }
-
-    # copy to the root dir (i.e. PONYPATH) for linking
-    Copy-Item -Force -Path "$libsDir/lib/ssl.lib" -Destination "$rootDir/ssl.lib"
-    Copy-Item -Force -Path "$libsDir/lib/crypto.lib" -Destination "$rootDir/crypto.lib"
-    Copy-Item -Force -Path "$libsDir/lib/tls.lib" -Destination "$rootDir/tls.lib"
   }
 }
 
@@ -191,17 +151,6 @@ switch ($Command.ToLower())
     $output = (corral fetch)
     $output | ForEach-Object { Write-Host $_ }
     if ($LastExitCode -ne 0) { throw "Error" }
-    break
-  }
-
-  "libs"
-  {
-    if (-not (Test-Path $libsDir))
-    {
-      mkdir "$libsDir"
-    }
-
-    BuildLibs
     break
   }
 
@@ -283,6 +232,6 @@ switch ($Command.ToLower())
 
   default
   {
-    throw "Unknown command '$Command'; must be one of (fetch, libs, build, test, buildtest, install, package, clean)."
+    throw "Unknown command '$Command'; must be one of (fetch, build, test, buildtest, install, package, clean)."
   }
 }


### PR DESCRIPTION
- Remove `BuildLibs` function and `libs` command from `make.ps1`
- Add `.ci-scripts/windows-install-libressl.ps1` to download prebuilt binaries from LibreSSL GitHub releases
- Update Windows CI workflows (pr, nightlies, release) to use the new script instead of building from source