### PR TITLE
Remove stable from supported applications

### DIFF
--- a/.release-notes/remove-stable.md
+++ b/.release-notes/remove-stable.md
@@ -1,0 +1,3 @@
+## Remove stable from supported applications
+
+The `stable` package manager is no longer maintained and has been removed from the list of applications that ponyup can install. Running `ponyup update stable` will now report an unknown package error.

--- a/cmd/packages.pony
+++ b/cmd/packages.pony
@@ -31,10 +31,6 @@ primitive ChangelogToolApplication is Application
   fun name(): String => "changelog-tool"
   fun binaries(): Array[Binary] val => [Binary("changelog-tool")]
 
-primitive StableApplication is Application
-  fun name(): String => "stable"
-  fun binaries(): Array[Binary] val => [Binary("stable")]
-
 primitive Packages
   fun apply(): Array[Application] box =>
     ifdef windows then
@@ -45,7 +41,6 @@ primitive Packages
         PonycApplication
         PonyupApplication
         ChangelogToolApplication
-        StableApplication
       ]
     end
 
@@ -55,7 +50,6 @@ primitive Packages
     | "corral" => CorralApplication
     | "ponyup" => PonyupApplication
     | "changelog-tool" => ChangelogToolApplication
-    | "stable" => StableApplication
     else
       error
     end


### PR DESCRIPTION
## Summary

- Remove `StableApplication` primitive and all references from the package list
- `ponyup update stable` will now report an unknown package error
- The `stable` package manager is no longer maintained

Closes #361

## Test plan

- [x] Compiles cleanly (both ponyup and test binaries)
- [x] `parse platform` test passes