### PR TITLE
Use releases repository for init script on macOS

### DIFF
--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -11,12 +11,6 @@ fi
 
 default_repository="releases"
 
-if [ "$(uname -s)" = "Darwin" ]; then
-  # we have to use nightly releases on macOS
-  # see https://github.com/ponylang/ponyup/issues/117
-  default_repository="nightlies"
-fi
-
 exit_usage() {
   printf "%s\n\n" "ponyup-init.sh"
   echo "Options:"


### PR DESCRIPTION
There used to be an issue on macOS that required installing ponyup nightly but I believe that's no longer relevant. Updates the init shell script to download ponyup from the releases repository instead.