### PR TITLE
Add workflow and script for building vendored LibreSSL

### DIFF
--- a/.ci-scripts/build-macos-libressl.bash
+++ b/.ci-scripts/build-macos-libressl.bash
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+#
+# Builds LibreSSL from source for the current macOS architecture and places
+# the static libraries in the repo's lib/darwin-* directory.
+#
+# This script is called by the "Update vendored LibreSSL" workflow. It runs
+# on macOS CI runners (the same ones used for release builds) so that the
+# compiled code targets the same generic CPUs as nightlies and releases.
+#
+# Environment:
+#   LIBRESSL_VERSION  LibreSSL version to build (default: 4.2.0)
+#
+
+set -o errexit
+set -o nounset
+
+LIBRESSL_VERSION="${LIBRESSL_VERSION:-4.2.0}"
+
+# Determine architecture and map to directory name
+UNAME_M=$(uname -m)
+case "${UNAME_M}" in
+arm64)
+  LIB_DIR="lib/darwin-arm64"
+  CMAKE_ARCH="arm64"
+  ;;
+x86_64)
+  LIB_DIR="lib/darwin-x86-64"
+  CMAKE_ARCH="x86_64"
+  ;;
+*)
+  echo "Unsupported architecture: ${UNAME_M}"
+  exit 1
+  ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARBALL="libressl-${LIBRESSL_VERSION}.tar.gz"
+URL="https://github.com/libressl/portable/releases/download/v${LIBRESSL_VERSION}/${TARBALL}"
+
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+echo "Downloading LibreSSL ${LIBRESSL_VERSION}..."
+curl -fsSL "${URL}" -o "${WORK_DIR}/${TARBALL}"
+
+echo "Extracting..."
+tar xzf "${WORK_DIR}/${TARBALL}" -C "${WORK_DIR}"
+
+SRC_DIR="${WORK_DIR}/libressl-${LIBRESSL_VERSION}"
+BUILD_DIR="${WORK_DIR}/build"
+
+echo "Building static libraries for ${CMAKE_ARCH}..."
+cmake -B "${BUILD_DIR}" -S "${SRC_DIR}" \
+  -DBUILD_SHARED_LIBS=OFF \
+  -DLIBRESSL_APPS=OFF \
+  -DLIBRESSL_TESTS=OFF \
+  -DCMAKE_OSX_ARCHITECTURES="${CMAKE_ARCH}"
+
+cmake --build "${BUILD_DIR}" --parallel
+
+echo "Copying static libraries to ${LIB_DIR}..."
+mkdir -p "${REPO_ROOT}/${LIB_DIR}"
+cp "${BUILD_DIR}/ssl/libssl.a" "${REPO_ROOT}/${LIB_DIR}/"
+cp "${BUILD_DIR}/crypto/libcrypto.a" "${REPO_ROOT}/${LIB_DIR}/"
+cp "${BUILD_DIR}/tls/libtls.a" "${REPO_ROOT}/${LIB_DIR}/"
+
+echo "Done. Static libraries for ${CMAKE_ARCH}:"
+ls -la "${REPO_ROOT}/${LIB_DIR}/"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lib/**/*.a binary

--- a/.github/workflows/update-libressl.yml
+++ b/.github/workflows/update-libressl.yml
@@ -1,0 +1,92 @@
+name: Update vendored LibreSSL
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'LibreSSL version (e.g., 4.2.0)'
+        required: true
+        default: '4.2.0'
+      branch:
+        description: 'Push to this existing branch (leave empty to create a new branch and PR)'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build-arm64:
+    name: Build LibreSSL for arm64
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Build LibreSSL
+        run: bash .ci-scripts/build-macos-libressl.bash
+        env:
+          LIBRESSL_VERSION: ${{ inputs.version }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: libressl-darwin-arm64
+          path: lib/darwin-arm64/*.a
+
+  build-x86-64:
+    name: Build LibreSSL for x86-64
+    runs-on: macos-26-intel
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Build LibreSSL
+        run: bash .ci-scripts/build-macos-libressl.bash
+        env:
+          LIBRESSL_VERSION: ${{ inputs.version }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: libressl-darwin-x86-64
+          path: lib/darwin-x86-64/*.a
+
+  vendor:
+    name: Commit vendored libraries
+    needs: [build-arm64, build-x86-64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+          token: ${{ secrets.RELEASE_TOKEN }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: libressl-darwin-arm64
+          path: lib/darwin-arm64/
+      - uses: actions/download-artifact@v4
+        with:
+          name: libressl-darwin-x86-64
+          path: lib/darwin-x86-64/
+      - name: Commit and push
+        run: |
+          git config user.name "Ponylang Main Bot"
+          git config user.email "ponylang.main@gmail.com"
+
+          if [ -n "${{ inputs.branch }}" ]; then
+            # Push to the specified existing branch
+            git add lib/
+            git commit -m "Vendor LibreSSL ${{ inputs.version }} static libraries for macOS"
+            git push
+          else
+            # Create a new branch and open a PR
+            BRANCH="update-libressl-${{ inputs.version }}"
+            git checkout -b "${BRANCH}"
+            git add lib/
+            git commit -m "Vendor LibreSSL ${{ inputs.version }} static libraries for macOS"
+            git push -u origin "${BRANCH}"
+            gh pr create \
+              --title "Update vendored LibreSSL to ${{ inputs.version }}" \
+              --body "$(cat <<'EOF'
+          Updates the vendored LibreSSL static libraries for macOS (arm64 and x86-64) to version ${{ inputs.version }}.
+
+          Built on the same CI runners used for release builds.
+          EOF
+            )"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Adds infrastructure for vendoring LibreSSL static libraries for macOS. This is the first step toward statically linking LibreSSL on macOS to eliminate the runtime dependency on Homebrew's LibreSSL (#127).

Once merged, the "Update vendored LibreSSL" workflow can be triggered from the Actions tab to build the `.a` files and commit them. A follow-up PR will add the Makefile changes, remove the brew dependency from CI scripts, and update the README.