### PR TITLE
Statically link LibreSSL on macOS

### DIFF
--- a/.ci-scripts/macos-arm64-install-pony-tools.bash
+++ b/.ci-scripts/macos-arm64-install-pony-tools.bash
@@ -15,13 +15,6 @@ case "${1}" in
   exit 1
 esac
 
-#
-# Libresll is required for ponyup
-#
-
-brew update
-brew install libressl
-
 pushd /tmp || exit
 mkdir ponyc
 echo ""https://dl.cloudsmith.io/public/ponylang/${REPO}/raw/versions/latest/ponyc-arm64-apple-darwin.tar.gz""

--- a/.ci-scripts/macos-x86-install-pony-tools.bash
+++ b/.ci-scripts/macos-x86-install-pony-tools.bash
@@ -16,13 +16,6 @@ case "${1}" in
 esac
 
 #
-# Libressl is required for ponyup
-#
-
-brew update
-brew install libressl
-
-#
 # Install ponyc the hard way
 # It will end up in /tmp/ponyc/ with the binary at /tmp/ponyc/bin/ponyc
 #

--- a/.ci-scripts/release/arm64-apple-darwin-nightly.bash
+++ b/.ci-scripts/release/arm64-apple-darwin-nightly.bash
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# x86-64-unknown-linux release:
+# arm64-apple-darwin nightly:
 #
-# - Builds release package
+# - Builds nightly package
 # - Uploads to Cloudsmith
 #
 # Tools required in the environment that runs this:
@@ -12,7 +12,6 @@
 # - GNU coreutils
 # - GNU gzip
 # - GNU make
-# - libressl
 # - ponyc
 # - corral
 # - GNU tar

--- a/.ci-scripts/release/arm64-apple-darwin-release.bash
+++ b/.ci-scripts/release/arm64-apple-darwin-release.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# x86-64-unknown-linux release:
+# arm64-apple-darwin release:
 #
 # - Builds release package
 # - Uploads to Cloudsmith
@@ -12,7 +12,6 @@
 # - GNU coreutils
 # - GNU gzip
 # - GNU make
-# - libressl
 # - ponyc
 # - corral
 # - GNU tar

--- a/.ci-scripts/release/x86-64-apple-darwin-nightly.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-nightly.bash
@@ -10,7 +10,6 @@
 # - GNU coreutils
 # - GNU gzip
 # - GNU make
-# - libressl
 # - ponyc
 # - corral
 # - GNU tar

--- a/.ci-scripts/release/x86-64-apple-darwin-release.bash
+++ b/.ci-scripts/release/x86-64-apple-darwin-release.bash
@@ -10,7 +10,6 @@
 # - GNU coreutils
 # - GNU gzip
 # - GNU make
-# - libressl
 # - ponyc
 # - corral
 # - GNU tar

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -169,7 +169,9 @@ jobs:
       - name: install pony tools
         run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
       - name: brew install dependencies
-        run: brew install coreutils
+        run: |
+          brew update
+          brew install coreutils
       - name: pip install dependencies
         run: pip3 install --break-system-packages --upgrade cloudsmith-cli
       - name: Build and upload
@@ -196,7 +198,9 @@ jobs:
       - name: install pony tools
         run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
-        run: brew install coreutils
+        run: |
+          brew update
+          brew install coreutils
       - name: pip install dependencies
         run: pip3 install --upgrade --break-system-packages cloudsmith-cli
       - name: Build and upload

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,9 @@ jobs:
       - name: install pony tools
         run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
       - name: brew install dependencies
-        run: brew install coreutils
+        run: |
+          brew update
+          brew install coreutils
       - name: pip install dependencies
         run: pip3 install --break-system-packages --upgrade cloudsmith-cli
       - name: Build and upload
@@ -100,7 +102,9 @@ jobs:
       - name: install pony tools
         run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
-        run: brew install coreutils
+        run: |
+          brew update
+          brew install coreutils
       - name: pip install dependencies
         run: pip3 install --upgrade --break-system-packages cloudsmith-cli
       - name: Build and upload

--- a/.release-notes/static-link-libressl-macos.md
+++ b/.release-notes/static-link-libressl-macos.md
@@ -1,0 +1,7 @@
+## Statically link LibreSSL on macOS
+
+macOS builds of ponyup now statically link LibreSSL instead of dynamically linking against Homebrew's version. Previously, when Homebrew updated LibreSSL to a newer version, existing ponyup binaries would break because the dynamic library version changed. You'd have to reinstall ponyup to get it working again.
+
+With this change, the LibreSSL libraries are baked into the ponyup binary itself. You no longer need to install LibreSSL via Homebrew to use ponyup on macOS, and Homebrew updates won't break your existing installation.
+
+The `ponyup-init.sh` script also now defaults to release builds on macOS instead of nightlies. The nightly default was a workaround for this same problem — nightlies were rebuilt daily against the current Homebrew LibreSSL, so they were less likely to be broken. That workaround is no longer needed.

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ static ?= false
 linker ?=
 
 ssl ?= libressl
+libressl_path ?=
 PONYC_FLAGS ?=
 
 BUILD_DIR ?= build/$(config)
@@ -28,6 +29,18 @@ else ifeq ($(ssl), 1.1.x)
 	PONYC_FLAGS += -Dopenssl_1.1.x
 else ifeq ($(ssl), libressl)
 	PONYC_FLAGS += -Dlibressl
+	ifeq ($(libressl_path),)
+		ifeq ($(shell uname -s),Darwin)
+			ifeq ($(shell uname -m),arm64)
+				libressl_path := lib/darwin-arm64
+			else
+				libressl_path := lib/darwin-x86-64
+			endif
+		endif
+	endif
+	ifneq ($(libressl_path),)
+		PONYC_FLAGS += --path $(libressl_path)
+	endif
 else
 	$(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
 endif

--- a/README.md
+++ b/README.md
@@ -8,15 +8,6 @@ This project is currently beta software.
 
 ## Usage
 
-### Install dependencies
-
-#### macOS
-
-```bash
-brew update
-brew install libressl
-```
-
 ### Install ponyup
 
 On Unix:
@@ -135,3 +126,11 @@ Ponyup is able to detect the CPU architecture and operating system of the platfo
   ```
 
   This is likely caused by a target triple that does not specify the libc ABI for the platform, as detected by `cc -dumpmachine`. The solution is to manually set the platform identifier using `ponyup default <platform>`, where `<platform>` is a platform identifier such as `x86_64-linux-ubuntu24.04`.
+
+## Development
+
+### Vendored LibreSSL
+
+macOS builds statically link against vendored LibreSSL libraries in `lib/`. This eliminates the runtime dependency on Homebrew's LibreSSL, which would break when Homebrew updates to a newer version.
+
+To update the vendored LibreSSL version, trigger the "Update vendored LibreSSL" workflow from the Actions tab with the desired version number. The workflow builds on both macOS architectures (using the same CI runners as release builds) and opens a PR with the updated `.a` files.

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -11,12 +11,6 @@ fi
 
 default_repository="releases"
 
-if [ "$(uname -s)" = "Darwin" ]; then
-  # we have to use nightly releases on macOS
-  # see https://github.com/ponylang/ponyup/issues/117
-  default_repository="nightlies"
-fi
-
 exit_usage() {
   printf "%s\n\n" "ponyup-init.sh"
   echo "Options:"


### PR DESCRIPTION
The Makefile now auto-detects macOS and points ponyc at the vendored static libraries in `lib/darwin-{arm64,x86-64}/`. This eliminates the runtime dependency on Homebrew's LibreSSL, which broke whenever Homebrew updated to a newer version.

Removes `brew install libressl` from the macOS CI install scripts and updates the README to remove the macOS LibreSSL dependency section. The init script now defaults to release builds on macOS instead of nightlies — the nightly default was a workaround for this same problem. Bootstrap tests still use brew since the currently-distributed nightly binary dynamically links LibreSSL.

Closes #127