### PR TITLE
Disable Windows Defender in CI

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -73,6 +73,8 @@ jobs:
     name: Build and upload x86-64-pc-windows-msvc-nightly to Cloudsmith
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
@@ -119,6 +121,8 @@ jobs:
     name: Build and upload arm64-pc-windows-msvc-nightly to Cloudsmith
     runs-on: windows-11-arm
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -259,6 +259,8 @@ jobs:
     name: x86-64 Windows tests
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
@@ -289,6 +291,8 @@ jobs:
     name: arm64 Windows tests
     runs-on: windows-11-arm
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,8 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
@@ -155,6 +157,8 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |


### PR DESCRIPTION
Disable Windows Defender real-time monitoring as the first step in all Windows CI jobs.