### PR TITLE
Build with ponyc 0.63.1

### DIFF
--- a/.release-notes/build-with-ponyc-0.63.1.md
+++ b/.release-notes/build-with-ponyc-0.63.1.md
@@ -1,0 +1,3 @@
+## Build with ponyc 0.63.1
+
+ponyup now requires ponyc 0.63.1 or later to build from source.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ ponyup default x86_64-linux-ubuntu24.04
 
 ## Development
 
+Building from source requires ponyc 0.63.1 or later.
+
 ### Vendored LibreSSL
 
 macOS builds statically link against vendored LibreSSL libraries in `lib/`. This eliminates the runtime dependency on Homebrew's LibreSSL, which would break when Homebrew updates to a newer version.

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.1.5"
+      "version": "0.2.0"
     }
   ],
   "info": {


### PR DESCRIPTION
Update courier to 0.2.0 which requires ponyc 0.63.1 or later.