### PR TITLE
Update to courier 0.2.1

### DIFF
--- a/cmd/http_handlers.pony
+++ b/cmd/http_handlers.pony
@@ -172,6 +172,13 @@ actor _QueryConnection is courier.HTTPClientConnectionActor
       _http.close()
     end
 
+  fun ref on_timer_failure() =>
+    _notify.log(Err,
+      "query: failed to arm timeout timer for " + _url.host
+        + ", aborting request")
+    _cb(QueryError)
+    _http.close()
+
 actor _DownloadConnection is courier.HTTPClientConnectionActor
   var _http: courier.HTTPClientConnection =
     courier.HTTPClientConnection.none()
@@ -287,6 +294,13 @@ actor _DownloadConnection is courier.HTTPClientConnectionActor
       _dump.failed()
       _http.close()
     end
+
+  fun ref on_timer_failure() =>
+    _notify.log(Err,
+      "download: failed to arm timeout timer for " + _url.host
+        + ", aborting download")
+    _dump.failed()
+    _http.close()
 
 actor DLDump
   let _notify: PonyupNotify

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.2.0"
+      "version": "0.2.1"
     }
   ],
   "info": {


### PR DESCRIPTION
Bumps courier to 0.2.1 (adds `on_timer_failure()` callback) and implements the new callback on `_QueryConnection` and `_DownloadConnection` so an ENOMEM-driven timer-arming failure surfaces as a failed request instead of hanging silently until the remote responds.