### PR TITLE
Write SHA-512 sibling in binary mode

### DIFF
--- a/.ci-scripts/release/github_release.py
+++ b/.ci-scripts/release/github_release.py
@@ -90,8 +90,11 @@ def write_sha512_sibling(archive_path):
         for chunk in iter(lambda: f.read(1024 * 1024), b''):
             h.update(chunk)
     sibling_path = archive_path + '.sha512'
-    with open(sibling_path, 'w') as f:
-        f.write(h.hexdigest() + '\n')
+    # Binary mode: keep the digest file byte-identical across platforms.
+    # Text mode on Windows would rewrite '\n' as '\r\n' and produce Windows
+    # archives with CRLF-terminated siblings while Linux/macOS produce LF.
+    with open(sibling_path, 'wb') as f:
+        f.write((h.hexdigest() + '\n').encode('ascii'))
     return sibling_path
 
 


### PR DESCRIPTION
Python's default text mode on Windows translates `\n` to `\r\n` on write, so a Windows run of `github_release.py` would produce CRLF-terminated `.sha512` siblings while Linux/macOS produce LF. Future consumers byte-compare these files, so switch to binary mode with an explicit ASCII encode to keep them byte-identical across platforms.

Defensive fix mirroring ponylang/ponyc#5233 — the same script is duplicated across corral, ponyup, ponyc, and changelog-tool pending centralization.