### PR TITLE
Add Ubuntu 26.04 as a supported platform

### DIFF
--- a/.ci-dockerfiles/ubuntu26.04-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/ubuntu26.04-bootstrap-tester/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/ubuntu/ubuntu:26.04
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyup"
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     ca-certificates \
+     clang \
+     curl \
+     git \
+     libssl-dev \
+     lsb-release \
+     make \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN git config --global --add safe.directory /__w/ponyup/ponyup

--- a/.ci-dockerfiles/ubuntu26.04-bootstrap-tester/build-and-push.bash
+++ b/.ci-dockerfiles/ubuntu26.04-bootstrap-tester/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyup-ci-ubuntu26.04-bootstrap-tester"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="ubuntu26.04-builder-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/arm64,linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.github/workflows/build-bootstrap-tester-image.yml
+++ b/.github/workflows/build-bootstrap-tester-image.yml
@@ -12,6 +12,7 @@ on:
           - alpine3.22-bootstrap-tester
           - alpine3.23-bootstrap-tester
           - ubuntu24.04-bootstrap-tester
+          - ubuntu26.04-bootstrap-tester
 
 permissions:
   packages: write
@@ -100,3 +101,24 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-dockerfiles/ubuntu24.04-bootstrap-tester/build-and-push.bash
+
+  ubuntu26_04-bootstrap-tester:
+    if: ${{ github.event.inputs.builder-name == 'ubuntu26.04-bootstrap-tester' }}
+    runs-on: ubuntu-latest
+
+    name: ubuntu26.04-bootstrap-tester
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/ubuntu26.04-bootstrap-tester/build-and-push.bash

--- a/.github/workflows/ponyup-tier2.yml
+++ b/.github/workflows/ponyup-tier2.yml
@@ -228,6 +228,31 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  arm64-ubuntu26_04-bootstrap:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    name: arm64 Ubuntu 26.04 bootstrap
+    runs-on: ubuntu-24.04-arm
+    container:
+        image: ghcr.io/ponylang/ponyup-ci-ubuntu26.04-bootstrap-tester:20260425
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Bootstrap test
+        run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   arm64-windows:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has-changes == 'true'
@@ -395,6 +420,31 @@ jobs:
           brew install libressl
       - name: Bootstrap test
         run: SSL=libressl .ci-scripts/test-bootstrap.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
+  x86-64-ubuntu24_04-bootstrap:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    name: x86-64 Ubuntu 24.04 bootstrap
+    runs-on: ubuntu-latest
+    container:
+        image: ghcr.io/ponylang/ponyup-ci-ubuntu24.04-bootstrap-tester:20250603
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Bootstrap test
+        run: SSL=3.0.x .ci-scripts/test-bootstrap.sh
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,11 +28,11 @@ jobs:
       - name: Bootstrap test
         run: SSL=libressl .ci-scripts/test-bootstrap.sh
 
-  x86-64-ubuntu24_04-bootstrap:
-    name: x86-64 Ubuntu 24.04 bootstrap
+  x86-64-ubuntu26_04-bootstrap:
+    name: x86-64 Ubuntu 26.04 bootstrap
     runs-on: ubuntu-latest
     container:
-        image: ghcr.io/ponylang/ponyup-ci-ubuntu24.04-bootstrap-tester:20250603
+        image: ghcr.io/ponylang/ponyup-ci-ubuntu26.04-bootstrap-tester:20260425
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Bootstrap test

--- a/.release-notes/ubuntu26.04.md
+++ b/.release-notes/ubuntu26.04.md
@@ -1,0 +1,3 @@
+## Add Ubuntu 26.04 as a supported platform
+
+We've added support for Ubuntu 26.04. This means that if you are using `ponyup` on an arm64 or amd64 system with Ubuntu 26.04, it will now recognize it as a supported platform and allow you to install `ponyc` and other related packages.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Defaults: pic=true
 Ponyup determines the target platform from the `.platform` file in its data directory. Use `ponyup default` to set it:
 
 ```console
-ponyup default x86_64-linux-ubuntu24.04
+ponyup default x86_64-linux-ubuntu26.04
 ```
 
 ### Common Issues
@@ -129,7 +129,7 @@ ponyup default x86_64-linux-ubuntu24.04
   error: unexpected selection: ponyc release latest x86_64-unknown-linux
   ```
 
-  This is likely caused by a target triple that does not specify the libc ABI for the platform, as detected by `cc -dumpmachine`. The solution is to manually set the platform identifier using `ponyup default <platform>`, where `<platform>` is a platform identifier such as `x86_64-linux-ubuntu24.04`.
+  This is likely caused by a target triple that does not specify the libc ABI for the platform, as detected by `cc -dumpmachine`. The solution is to manually set the platform identifier using `ponyup default <platform>`, where `<platform>` is a platform identifier such as `x86_64-linux-ubuntu26.04`.
 
 ## Development
 

--- a/cmd/cli.pony
+++ b/cmd/cli.pony
@@ -101,7 +101,7 @@ primitive CLI
           ])?
         CommandSpec.leaf(
           "default",
-          "Set the default platform (such as x86_64-linux-ubuntu24.04)",
+          "Set the default platform (such as x86_64-linux-ubuntu26.04)",
           [],
           [ ArgSpec.string("platform")
           ])?

--- a/cmd/cloudsmith.pony
+++ b/cmd/cloudsmith.pony
@@ -41,7 +41,7 @@ primitive Cloudsmith
     q.append(application_name)
     if not all_platforms then
       // Transform platform to match Cloudsmith package naming convention
-      // (e.g. x86_64-linux-ubuntu22.04 -> x86-64-unknown-linux-ubuntu22.04)
+      // (e.g. x86_64-linux-ubuntu26.04 -> x86-64-unknown-linux-ubuntu26.04)
       // Guards prevent double-transformation if already in Cloudsmith format.
       let p = platform.clone()
       if not p.contains("x86-64") then p.replace("x86_64", "x86-64") end

--- a/cmd/main.pony
+++ b/cmd/main.pony
@@ -79,7 +79,7 @@ actor Main is PonyupNotify
       else
         log(Err, "".join(
           [ "unable to determine platform, use `ponyup default <platform>`"
-            " to set one\n  (e.g. ponyup default x86_64-linux-ubuntu24.04)"
+            " to set one\n  (e.g. ponyup default x86_64-linux-ubuntu26.04)"
           ].values()))
         return
       end

--- a/cmd/packages.pony
+++ b/cmd/packages.pony
@@ -67,7 +67,7 @@ primitive Packages
     It is assumed that Arch field does not contain a `-` character, such as
     x86-64 which must be replaced by either x86_64, x64, or amd64. Vendor fields
     (unknown, pc, apple, etc.) are ignored. ABI fields are used to detect the
-    libc implementation (glibc or musl) or distribution (ubuntu24.04) on
+    libc implementation (glibc or musl) or distribution (ubuntu26.04) on
     Linux-based platforms. Such ABI fields are required for Linux for some
     packages, such as ponyc.
 

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -86,6 +86,9 @@ Linux*)
   case $(cc -dumpmachine) in
   *gnu)
     case "$(lsb_release -d)" in
+    *"Ubuntu 26.04"*)
+      platform_triple_distro="ubuntu26.04"
+      ;;
     *"Ubuntu 24.04"*)
       platform_triple_distro="ubuntu24.04"
       ;;


### PR DESCRIPTION
Adds Ubuntu 26.04 as a supported bootstrap-test platform. Bootstrap-tester image, CI bootstrap jobs (x86-64 in tier 1, arm64 in tier 2), and `ponyup-init.sh` detection are all included.

Demotes `x86-64-ubuntu24_04-bootstrap` from tier 1 to tier 2 to keep "latest x86-64 of each distro family" as the tier-1 PR coverage.

Promotes the canonical example platform string in `--help` text, error messages, and docs from `ubuntu24.04` to `ubuntu26.04`.