### PR TITLE
Lint Python files in .ci-scripts on every PR (issue #411)

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -1,0 +1,22 @@
+name: Lint Python Scripts
+
+on: pull_request
+
+concurrency:
+  group: lint-python-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Check Python files under .ci-scripts/
+        uses: docker://ghcr.io/astral-sh/ruff:0.15.12
+        with:
+          args: check .ci-scripts


### PR DESCRIPTION
Closes #411.

Adds a new workflow `lint-python.yml` that runs `ruff check .ci-scripts` on every PR. Default ruff rules (E + F) are tight enough to catch undefined names, bad imports, and syntax errors without bikeshedding style.

Modeled on `lint-action-workflows.yml` so it follows the existing one-concern-per-workflow convention. Pinned to `ghcr.io/astral-sh/ruff:0.15.12` (the current stable docker tag).

Currently `.ci-scripts/release/github_release.py` passes `ruff check` with no findings, so this PR is purely additive — no script changes needed.

A sister PR can be opened against `ponylang/corral` to cover #316.