### PR TITLE
Pin ruff docker image by digest

### DIFF
--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Check Python files under .ci-scripts/
-        uses: docker://ghcr.io/astral-sh/ruff:0.15.12
+        # ruff 0.15.12
+        uses: docker://ghcr.io/astral-sh/ruff@sha256:e42f3866bb9f701dbc459cdec3f5aca06511e6a38e6e04bfd4d04a2be26d4fd4
         with:
           args: check .ci-scripts


### PR DESCRIPTION
Pinning the ruff docker image by tag (`:0.15.12`) trusts that the tag is never re-pushed. Pinning by digest makes the reference immutable, so a compromised or rewritten upstream tag can't silently change what runs in CI. Comment retains the human-readable version.

Follow-up to #422.