### PR TITLE
Add isolated experiment for publishing ponyup nightlies to GHCR

### DIFF
--- a/.ci-scripts/release/ghcr-experiment.bash
+++ b/.ci-scripts/release/ghcr-experiment.bash
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# EXPERIMENTAL: build the x86-64-unknown-linux ponyup nightly and publish it to
+# GHCR only (no Cloudsmith). Driven by experiment-ghcr-nightly.yml to validate
+# the GHCR publishing pipeline in isolation, without touching the production
+# nightly pipeline. Publishes under the throwaway `ponyup-experiment` package
+# name. Delete this script and its workflow once GHCR publishing is validated
+# and integrated into the real nightly scripts.
+# See https://github.com/ponylang/ponyup/discussions/412.
+#
+# Tools required in the environment that runs this:
+#
+# - bash
+# - corral
+# - GNU make
+# - gzip
+# - ponyc (musl based version)
+# - python3
+# - tar
+
+set -o errexit
+
+# Pull in shared configuration specific to this repo
+base=$(dirname "$0")
+# shellcheck source=.ci-scripts/release/config.bash
+source "${base}/config.bash"
+
+# Verify ENV is set up correctly
+if [[ -z "${GITHUB_REPOSITORY}" ]]; then
+  echo -e "\e[31mName of this repository needs to be set in GITHUB_REPOSITORY."
+  echo -e "\e[31mShould be in the form OWNER/REPO, for example:"
+  echo -e "\e[31m     ponylang/ponyup"
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  echo -e "\e[31mGITHUB_TOKEN needs to be set for GHCR publishing."
+  echo -e "Exiting.\e[0m"
+  exit 1
+fi
+
+if [[ -z "${APPLICATION_NAME}" ]]; then
+  echo -e "\e[31mAPPLICATION_NAME needs to be set."
+  echo -e "\e[31mExiting.\e[0m"
+  exit 1
+fi
+
+# no unset variables allowed from here on out
+# allow above so we can display nice error messages for expected unset variables
+set -o nounset
+
+TODAY=$(date +%Y%m%d)
+
+# Compiler target parameters
+ARCH=x86-64
+
+# Triple construction
+VENDOR=unknown
+OS=linux
+TRIPLE=${ARCH}-${VENDOR}-${OS}
+
+# Build parameters
+BUILD_PREFIX=$(mktemp -d)
+APPLICATION_VERSION="nightly-${TODAY}"
+BUILD_DIR=${BUILD_PREFIX}/${APPLICATION_VERSION}
+
+# Asset information
+PACKAGE_DIR=$(mktemp -d)
+PACKAGE=${APPLICATION_NAME}-${TRIPLE}
+ASSET_FILE=${PACKAGE_DIR}/${PACKAGE}.tar.gz
+
+# Build application installation
+echo -e "\e[34mBuilding ${APPLICATION_NAME}...\e[0m"
+make install prefix="${BUILD_DIR}" arch=${ARCH} \
+  version="${APPLICATION_VERSION}" static=true linker=bfd
+
+# Package it all up
+echo -e "\e[34mCreating .tar.gz of ${APPLICATION_NAME}...\e[0m"
+pushd "${BUILD_PREFIX}" || exit 1
+tar -cvzf "${ASSET_FILE}" -- *
+popd || exit 1
+
+# Ship it off to GHCR as an OCI artifact (experimental package name)
+echo -e "\e[34mUploading package to GHCR...\e[0m"
+python3 "${base}/ghcr_nightly.py" push ponyup-experiment "${TRIPLE}" \
+  "${TODAY}" "${ASSET_FILE}"

--- a/.ci-scripts/release/ghcr_nightly.py
+++ b/.ci-scripts/release/ghcr_nightly.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Publish a nightly tool archive to GHCR as an OCI artifact.
+
+Stdlib only so no pip install is required on any CI runner, matching the
+posture of github_release.py.
+
+Each (tool, platform) pair is one OCI image under a `nightly/` path segment:
+
+    ghcr.io/ponylang/nightly/<tool>-<triple>:<YYYYMMDD>
+
+See https://github.com/ponylang/ponyup/discussions/412 for the design.
+
+Usage:
+    ghcr_nightly.py push <tool> <triple> <version> <archive>
+    ghcr_nightly.py set-public <tool> <triple>
+
+`push` uploads the archive, uploads a config blob carrying metadata, and PUTs
+the OCI manifest. Auth uses GITHUB_TOKEN (needs `packages: write`).
+
+`set-public` attempts to make the package publicly pullable via the GitHub
+Packages API. Auth uses GHCR_VISIBILITY_TOKEN (a package-admin PAT; the
+workflow token cannot do this).
+"""
+
+import base64
+import datetime
+import hashlib
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+ENDC = '\033[0m'
+ERROR = '\033[31m'
+INFO = '\033[34m'
+
+REGISTRY = 'https://ghcr.io'
+API_BASE = 'https://api.github.com'
+API_VERSION = '2022-11-28'
+NAMESPACE = 'nightly'
+REQUEST_TIMEOUT = 300
+
+ARTIFACT_TYPE = 'application/vnd.ponylang.nightly.v1'
+CONFIG_TYPE = 'application/vnd.ponylang.nightly.config.v1+json'
+MANIFEST_TYPE = 'application/vnd.oci.image.manifest.v1+json'
+ARCHIVE_TYPE_TARGZ = 'application/vnd.ponylang.nightly.archive.v1.tar+gzip'
+ARCHIVE_TYPE_ZIP = 'application/vnd.ponylang.nightly.archive.v1.zip'
+
+
+def die(message):
+    print(ERROR + message + ENDC, file=sys.stderr)
+    sys.exit(1)
+
+
+def info(message):
+    print(INFO + message + ENDC)
+
+
+def require_env(name):
+    value = os.environ.get(name, '')
+    if not value:
+        die(f"{name} needs to be set in env. Exiting.")
+    return value
+
+
+def owner():
+    # GITHUB_REPOSITORY is "OWNER/REPO"; the registry namespace is the owner.
+    repo = require_env('GITHUB_REPOSITORY')
+    return repo.split('/')[0]
+
+
+def package_name(tool, triple):
+    return f'{NAMESPACE}/{tool}-{triple}'
+
+
+def repository(tool, triple):
+    return f'{owner()}/{package_name(tool, triple)}'
+
+
+def archive_media_type(archive):
+    if archive.endswith('.zip'):
+        return ARCHIVE_TYPE_ZIP
+    if archive.endswith('.tar.gz'):
+        return ARCHIVE_TYPE_TARGZ
+    die(f"Unsupported archive extension: {archive}")
+
+
+def digest_of(data):
+    return 'sha256:' + hashlib.sha256(data).hexdigest()
+
+
+def sha512_hex(data):
+    return hashlib.sha512(data).hexdigest()
+
+
+def request(method, url, headers=None, data=None):
+    """Perform an HTTP request, returning (status, response_headers, body).
+
+    Non-2xx responses are returned rather than raised so callers can decide;
+    network-level failures are fatal.
+    """
+    req = urllib.request.Request(url, data=data, headers=headers or {},
+                                 method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT) as r:
+            return r.status, dict(r.headers), r.read()
+    except urllib.error.HTTPError as e:
+        return e.code, dict(e.headers), e.read()
+    except (urllib.error.URLError, OSError) as e:
+        die(f"{method} {url} failed: {e}")
+
+
+def check(status, body, method, url, ok):
+    if status not in ok:
+        text = body.decode('utf-8', errors='replace') if body else ''
+        die(f"{method} {url} returned {status} (expected {ok})\n{text}")
+
+
+def pull_push_token(repo):
+    # Docker registry v2 token exchange. GHCR authenticates the token; the
+    # Basic-auth username is not significant, so fall back to the owner when
+    # GITHUB_ACTOR is unset (e.g. a bare `docker run`).
+    token = require_env('GITHUB_TOKEN')
+    user = os.environ.get('GITHUB_ACTOR') or owner()
+    creds = base64.b64encode(f"{user}:{token}".encode()).decode()
+    scope = f'repository:{repo}:pull,push'
+    query = urllib.parse.urlencode({'service': 'ghcr.io', 'scope': scope})
+    url = f'{REGISTRY}/token?{query}'
+    status, _, body = request('GET', url,
+                              headers={'Authorization': f'Basic {creds}'})
+    check(status, body, 'GET', url, (200,))
+    return json.loads(body)['token']
+
+
+def blob_exists(repo, digest, token):
+    url = f'{REGISTRY}/v2/{repo}/blobs/{digest}'
+    status, _, body = request('HEAD', url,
+                              headers={'Authorization': f'Bearer {token}'})
+    if status == 200:
+        return True
+    if status == 404:
+        return False
+    check(status, body, 'HEAD', url, (200, 404))
+
+
+def upload_blob(repo, data, digest, token):
+    if blob_exists(repo, digest, token):
+        info(f"Blob {digest} already present, skipping upload.")
+        return
+    # Start an upload session, then PUT the blob monolithically with the digest.
+    start = f'{REGISTRY}/v2/{repo}/blobs/uploads/'
+    status, resp_headers, body = request(
+        'POST', start, headers={'Authorization': f'Bearer {token}'})
+    check(status, body, 'POST', start, (202,))
+    location = resp_headers.get('Location')
+    if not location:
+        die(f"POST {start} returned no Location header")
+    if location.startswith('/'):
+        location = REGISTRY + location
+    sep = '&' if '?' in location else '?'
+    put_url = f'{location}{sep}digest={digest}'
+    status, _, body = request('PUT', put_url, data=data, headers={
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/octet-stream',
+    })
+    check(status, body, 'PUT', put_url, (201,))
+
+
+def put_manifest(repo, tag, manifest, token):
+    url = f'{REGISTRY}/v2/{repo}/manifests/{tag}'
+    status, _, body = request('PUT', url, data=manifest, headers={
+        'Authorization': f'Bearer {token}',
+        'Content-Type': MANIFEST_TYPE,
+    })
+    check(status, body, 'PUT', url, (201,))
+
+
+def cmd_push(tool, triple, version, archive):
+    if not os.path.isfile(archive):
+        die(f"File not found: {archive}")
+
+    repo = repository(tool, triple)
+    info(f"Publishing {os.path.basename(archive)} to "
+         f"{REGISTRY}/{repo}:{version}")
+
+    with open(archive, 'rb') as f:
+        archive_data = f.read()
+    built_at = (datetime.datetime.now(datetime.timezone.utc)
+                .strftime('%Y-%m-%dT%H:%M:%SZ'))
+    config = json.dumps({
+        'tool': tool,
+        'platform': triple,
+        'version': version,
+        'sha512': sha512_hex(archive_data),
+        'built_at': built_at,
+    }, sort_keys=True).encode('utf-8')
+
+    archive_digest = digest_of(archive_data)
+    config_digest = digest_of(config)
+
+    token = pull_push_token(repo)
+
+    info("Uploading config blob...")
+    upload_blob(repo, config, config_digest, token)
+    info("Uploading archive blob...")
+    upload_blob(repo, archive_data, archive_digest, token)
+
+    manifest = json.dumps({
+        'schemaVersion': 2,
+        'mediaType': MANIFEST_TYPE,
+        'artifactType': ARTIFACT_TYPE,
+        'config': {
+            'mediaType': CONFIG_TYPE,
+            'digest': config_digest,
+            'size': len(config),
+        },
+        'layers': [{
+            'mediaType': archive_media_type(archive),
+            'digest': archive_digest,
+            'size': len(archive_data),
+            'annotations': {
+                'org.opencontainers.image.title': os.path.basename(archive),
+            },
+        }],
+        'annotations': {
+            'org.opencontainers.image.created': built_at,
+        },
+    }).encode('utf-8')
+
+    info(f"Putting manifest {version}...")
+    put_manifest(repo, version, manifest, token)
+    info("Publish complete.")
+
+
+def cmd_set_public(tool, triple):
+    token = require_env('GHCR_VISIBILITY_TOKEN')
+    name = urllib.parse.quote(package_name(tool, triple), safe='')
+    url = f'{API_BASE}/orgs/{owner()}/packages/container/{name}/visibility'
+    body = json.dumps({'visibility': 'public'}).encode('utf-8')
+    info(f"Setting {package_name(tool, triple)} visibility to public...")
+    status, _, resp = request('PATCH', url, data=body, headers={
+        'Authorization': f'Bearer {token}',
+        'Accept': 'application/vnd.github+json',
+        'X-GitHub-Api-Version': API_VERSION,
+        'Content-Type': 'application/json',
+    })
+    check(status, resp, 'PATCH', url, (200, 204))
+    info("Visibility set to public.")
+
+
+def usage():
+    die("usage: ghcr_nightly.py push <tool> <triple> <version> <archive>\n"
+        "       ghcr_nightly.py set-public <tool> <triple>")
+
+
+def main(argv):
+    if len(argv) < 2:
+        usage()
+    command = argv[1]
+    if command == 'push':
+        if len(argv) != 6:
+            usage()
+        cmd_push(argv[2], argv[3], argv[4], argv[5])
+    elif command == 'set-public':
+        if len(argv) != 4:
+            usage()
+        cmd_set_public(argv[2], argv[3])
+    else:
+        usage()
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/.github/workflows/experiment-ghcr-nightly.yml
+++ b/.github/workflows/experiment-ghcr-nightly.yml
@@ -1,0 +1,61 @@
+name: (experiment) GHCR nightly publishing
+
+# EXPERIMENTAL and TEMPORARY: an isolated, manual-only validation of GHCR
+# nightly publishing for ponyup. It touches nothing in the production nightly
+# pipeline: it builds one platform (x86-64-unknown-linux), publishes it to GHCR
+# only (no Cloudsmith) under the throwaway `ponyup-experiment` package name, and
+# probes the two unknowns from discussion #412 — whether the undocumented
+# visibility API can flip an org package public, and whether the retention-policy
+# action accepts a multi-segment (slash-containing) package name.
+#
+# Delete this workflow, .ci-scripts/release/ghcr-experiment.bash, and the
+# experimental `ponyup-experiment` GHCR packages once the approach is validated
+# and integrated into the real nightly scripts.
+# See https://github.com/ponylang/ponyup/discussions/412.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+
+jobs:
+  build-and-publish:
+    name: Build and publish x86-64-unknown-linux to GHCR
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Build and publish to GHCR
+        run: bash .ci-scripts/release/ghcr-experiment.bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Observational only: the visibility API is undocumented and may not work
+      # for org packages, so this must not fail the run.
+      - name: Probe GHCR visibility flip
+        continue-on-error: true
+        run: python3 .ci-scripts/release/ghcr_nightly.py set-public ponyup-experiment x86-64-unknown-linux
+        env:
+          GHCR_VISIBILITY_TOKEN: ${{ secrets.DELETE_PACKAGES_TOKEN }}
+
+  prune:
+    name: Probe prune of multi-segment package name
+    runs-on: ubuntu-latest
+    needs:
+      - build-and-publish
+    steps:
+      # Observational only: confirms whether the action accepts the
+      # slash-containing `nightly/ponyup-experiment-*` name. Nothing is actually
+      # old enough to delete, so a success means "name accepted". Read the logs
+      # to see what it matched.
+      - name: Prune
+        # v3.0.1
+        continue-on-error: true
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        with:
+          account: ponylang
+          token: ${{ secrets.DELETE_PACKAGES_TOKEN }}
+          image-names: "nightly/ponyup-experiment-*"
+          tag-selection: tagged
+          cut-off: 90d


### PR DESCRIPTION
Temporary, isolated infrastructure to validate the GHCR nightly publishing approach from #412 before integrating it into the production nightly pipeline.

It adds three new files and touches nothing existing:
- `.ci-scripts/release/ghcr_nightly.py` — stdlib-only OCI push helper (`push` and `set-public` subcommands). This is the reusable core that the real integration will call.
- `.ci-scripts/release/ghcr-experiment.bash` — builds the x86-64-unknown-linux nightly and publishes it to GHCR only (no Cloudsmith), under a throwaway `ponyup-experiment` package name.
- `.github/workflows/experiment-ghcr-nightly.yml` — a manual-only workflow that runs the build, then probes the two open questions from #412.

It has to merge to `main` only because `workflow_dispatch` cannot fire for a workflow that exists solely on a feature branch. It is meant to be deleted (workflow, script, and the experimental GHCR packages) once the approach is validated.

What the run will tell us (the two parked questions from #412):
- Whether the undocumented GitHub Packages visibility API can flip an org package public (the `set-public` probe — observational, `continue-on-error`).
- Whether `snok/container-retention-policy` accepts a multi-segment, slash-containing package name like `nightly/ponyup-experiment-*` (the prune probe — observational, `continue-on-error`).

The real integration — wiring GHCR publishing into the production nightly scripts for all platforms, and eventually corral/ponyc — is a separate follow-up once this validates.

Design: #412