### PR TITLE
Guard Cloudsmith exit code before GHCR push in Windows nightlies

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -106,6 +106,11 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version  --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/nightlies build\ponyup-x86-64-pc-windows-msvc.zip
+          # In a pwsh step the step's exit code is that of the last native
+          # command, so a Cloudsmith failure would be masked by a subsequent
+          # successful GHCR push. Guard it: Cloudsmith is the primary download
+          # source and must not fail silently.
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Additionally publish to GHCR, reusing $version so both destinations
           # get the same date.
           python .ci-scripts\release\ghcr_nightly.py push ponyup x86-64-pc-windows-msvc $version build\ponyup-x86-64-pc-windows-msvc.zip
@@ -158,6 +163,11 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version  --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/nightlies build\ponyup-arm64-pc-windows-msvc.zip
+          # In a pwsh step the step's exit code is that of the last native
+          # command, so a Cloudsmith failure would be masked by a subsequent
+          # successful GHCR push. Guard it: Cloudsmith is the primary download
+          # source and must not fail silently.
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Additionally publish to GHCR, reusing $version so both destinations
           # get the same date.
           python .ci-scripts\release\ghcr_nightly.py push ponyup arm64-pc-windows-msvc $version build\ponyup-arm64-pc-windows-msvc.zip


### PR DESCRIPTION
The two Windows nightly jobs run the Cloudsmith push and the GHCR push in the same `pwsh` step. In a `pwsh` step the step's exit code is the exit code of the *last* native command, so a failed Cloudsmith push followed by a successful GHCR push exits 0 — the board stays green and no Zulip alert fires even though the nightly never reached Cloudsmith, the primary download source.

Guarding the Cloudsmith exit code before the GHCR push closes that gap. The Linux/macOS jobs are unaffected because their bash scripts run under `set -o errexit`, which already aborts before the GHCR push if Cloudsmith fails. This matches the guard ponyc's `release.yml` already uses between its Cloudsmith push and `github_release.py` upload.

Closes #435