### PR TITLE
Switch CI from ponyc nightly back to release

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
       - name: Build and upload
         run: |
           docker run --rm \
@@ -34,7 +34,7 @@ jobs:
             -e GITHUB_REPOSITORY=${{ github.repository }} \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GITHUB_ACTOR=${{ github.actor }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release \
             bash .ci-scripts/release/arm64-unknown-linux-nightly.bash
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -52,7 +52,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
@@ -81,9 +81,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -138,9 +138,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -192,7 +192,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
+        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
       - name: brew install dependencies
         run: |
           brew update
@@ -222,7 +222,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
         run: |
           brew update

--- a/.github/workflows/ponyup-tier2.yml
+++ b/.github/workflows/ponyup-tier2.yml
@@ -183,13 +183,13 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
-      - name: Test with most recent ponyc nightly
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      - name: Test with most recent ponyc release
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/root/project \
             -w /root/project \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release \
             make test
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -266,9 +266,9 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -282,7 +282,7 @@ jobs:
       - name: Install LibreSSL
         if: steps.cache-libressl.outputs.cache-hit != 'true'
         run: .ci-scripts\windows-install-libressl.ps1
-      - name: Test with most recent ponyc nightly
+      - name: Test with most recent ponyc release
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch 2>&1
@@ -385,8 +385,8 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: install pony tools
-        run: bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
-      - name: Test with the most recent ponyc nightly
+        run: bash .ci-scripts/macos-x86-install-pony-tools.bash release
+      - name: Test with the most recent ponyc release
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,10 +57,10 @@ jobs:
     name: x86-64 Linux tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with the most recent ponyc nightly
+      - name: Test with the most recent ponyc release
         run: make test
 
   arm64-macos:
@@ -69,8 +69,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
-      - name: Test with the most recent ponyc nightly
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
+      - name: Test with the most recent ponyc release
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test
@@ -84,9 +84,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -100,7 +100,7 @@ jobs:
       - name: Install LibreSSL
         if: steps.cache-libressl.outputs.cache-hit != 'true'
         run: .ci-scripts\windows-install-libressl.ps1
-      - name: Test with most recent ponyc nightly
+      - name: Test with most recent ponyc release
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch 2>&1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
       - name: Build and upload
         run: |
           docker run --rm \
@@ -67,7 +67,7 @@ jobs:
             -e CLOUDSMITH_API_KEY=${{ secrets.CLOUDSMITH_API_KEY }} \
             -e RELEASE_TOKEN=${{ secrets.RELEASE_TOKEN }} \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release \
             bash .ci-scripts/release/arm64-unknown-linux-release.bash
 
   x86-64-unknown-linux-release:
@@ -76,7 +76,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
@@ -94,7 +94,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
+        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
       - name: brew install dependencies
         run: |
           brew update
@@ -116,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
         run: |
           brew update
@@ -141,9 +141,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -184,9 +184,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl


### PR DESCRIPTION
Now that 0.64.0 is released, switch the CI workflows back from nightly ponyc to release ponyc.