### PR TITLE
Add Windows bootstrap tests to CI

### DIFF
--- a/.ci-scripts/test-bootstrap.ps1
+++ b/.ci-scripts/test-bootstrap.ps1
@@ -1,0 +1,21 @@
+$ErrorActionPreference = "Stop"
+
+# Install into the default prefix and keep the bin path in sync with it, so this
+# stays correct if ponyup-init.ps1's default -Prefix ever changes.
+$prefix = "$env:LOCALAPPDATA\ponyup"
+
+.\ponyup-init.ps1 -Repository nightlies -Prefix $prefix -SetPath $false
+
+$env:PATH = "$prefix\bin;" + $env:PATH
+
+# $ErrorActionPreference = "Stop" only makes cmdlet errors terminating; a native
+# command's non-zero exit aborts only under pwsh >= 7.4. Guard explicitly so a
+# failed update fails the job here, not opaquely at the later build step.
+ponyup update ponyc nightly --api-timeout 120 --retries 3
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+ponyup update corral nightly --api-timeout 120 --retries 3
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+.\make.ps1 -Command fetch 2>&1
+.\make.ps1 -Command build 2>&1
+.\make.ps1 -Command test 2>&1

--- a/.github/workflows/ponyup-tier2.yml
+++ b/.github/workflows/ponyup-tier2.yml
@@ -300,6 +300,43 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  arm64-windows-bootstrap:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    name: arm64 Windows bootstrap
+    runs-on: windows-11-arm
+    steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+      - uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Cache LibreSSL libs
+        id: cache-libressl
+        uses: actions/cache@v5.0.3
+        with:
+          path: |
+            ssl.lib
+            crypto.lib
+            tls.lib
+          key: libressl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ci-scripts/windows-install-libressl.ps1') }}
+      - name: Install LibreSSL
+        if: steps.cache-libressl.outputs.cache-hit != 'true'
+        run: .ci-scripts\windows-install-libressl.ps1
+      - name: Bootstrap test
+        run: .ci-scripts\test-bootstrap.ps1
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   ubuntu22_04-bootstrap:
     needs: check-for-changes
     if: needs.check-for-changes.outputs.has-changes == 'true'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -53,6 +53,28 @@ jobs:
       - name: Bootstrap test
         run: SSL=libressl .ci-scripts/test-bootstrap.sh
 
+  x86-64-windows-bootstrap:
+    name: x86-64 Windows bootstrap
+    runs-on: windows-2025-vs2026
+    steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
+      - uses: actions/checkout@v6.0.2
+      - name: Cache LibreSSL libs
+        id: cache-libressl
+        uses: actions/cache@v5.0.3
+        with:
+          path: |
+            ssl.lib
+            crypto.lib
+            tls.lib
+          key: libressl-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.ci-scripts/windows-install-libressl.ps1') }}
+      - name: Install LibreSSL
+        if: steps.cache-libressl.outputs.cache-hit != 'true'
+        run: .ci-scripts\windows-install-libressl.ps1
+      - name: Bootstrap test
+        run: .ci-scripts\test-bootstrap.ps1
+
   x86-64-linux:
     name: x86-64 Linux tests
     runs-on: ubuntu-latest

--- a/ponyup-init.ps1
+++ b/ponyup-init.ps1
@@ -1,4 +1,8 @@
-Param([string] $Prefix = "$env:LOCALAPPDATA\ponyup", [bool] $SetPath = $true)
+Param(
+  [string] $Prefix = "$env:LOCALAPPDATA\ponyup",
+  [bool] $SetPath = $true,
+  [string] $Repository = "releases"
+)
 $ErrorActionPreference = 'Stop'
 
 # Detect system architecture
@@ -28,14 +32,44 @@ $tempName = [System.Guid]::NewGuid()
 $tempPath = (Join-Path $tempParent $tempName)
 New-Item -ItemType Directory -Path $tempPath
 
-$downloadUrl = 'https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest'
+# Query the Cloudsmith API for the latest ponyup package in the chosen
+# repository. This mirrors ponyup-init.sh: it gives us the package version
+# (a semver for releases, a date for nightlies), the checksum, and the download
+# URL.
+$queryUrl = "https://api.cloudsmith.io/packages/ponylang/$Repository/"
+$query = "?query=ponyup-$Arch-pc-windows-msvc&page=1&page_size=1"
+Write-Host "Querying $queryUrl$query..."
+$response = @(Invoke-RestMethod -Uri "$queryUrl$query")
+$package = $response[0]
+# Cloudsmith returns `[]` for no match. Invoke-RestMethod unrolls that into an
+# empty array, so $response[0] is an empty Object[] (NOT $null) whose fields read
+# as empty. Guard on the fields we actually consume being present: this catches
+# the no-match case and a package that somehow lacks a checksum.
+if ((-not $package.version) -or (-not $package.cdn_url) -or
+    (-not $package.checksum_sha256)) {
+  Write-Error "Failed to find ponyup in the '$Repository' repository"
+  exit 1
+}
+$pkgVersion = $package.version
+$downloadUrl = $package.cdn_url
+# Cloudsmith exposes both checksum_sha256 and checksum_sha512. We use sha256 to
+# match ponyup-init.sh; this is intentionally different from ponyup's internal
+# downloader, which verifies sha512. Don't "align" them.
+$checksum = $package.checksum_sha256
 
 $zipName = "ponyup-$Arch-pc-windows-msvc.zip"
-$zipUrl = "$downloadUrl/$zipName"
 $zipPath = "$tempPath\$zipName"
 
-Write-Host "Downloading $zipUrl..."
-Invoke-WebRequest -Uri $zipUrl -Outfile $zipPath
+Write-Host "Downloading $downloadUrl..."
+Invoke-WebRequest -Uri $downloadUrl -Outfile $zipPath
+
+$dlChecksum = (Get-FileHash -Algorithm SHA256 -Path $zipPath).Hash.ToLower()
+if ($dlChecksum -ne $checksum.ToLower()) {
+  Remove-Item -Force $zipPath
+  Write-Error "checksum mismatch: expected $checksum, calculated $dlChecksum"
+  exit 1
+}
+Write-Host "checksum ok"
 
 $ponyupPath = $Prefix
 if (-not (Test-Path $ponyupPath)) {
@@ -49,29 +83,31 @@ $platform = "$PlatformStringArch-pc-windows-msvc"
 Write-Host "Setting platform to $platform..."
 Set-Content -Path "$ponyupPath\.platform" -Value $platform
 
-$version = & "$ponyupPath\bin\ponyup" version
-if ($version -match 'ponyup (\d+\.\d+\.\d+)') {
-  $lockStr = "ponyup-release-$($Matches[1])-$PlatformStringArch-windows"
-  Write-Host "Locking ponyup version to $lockStr..."
-  $lockPath = "$ponyupPath\.lock"
+# Build the lock string from the Cloudsmith package version, not from
+# `ponyup version`: a nightly's package version is a date, whereas the binary
+# reports its semver, so only the Cloudsmith version produces a correct lock
+# string for nightlies.
+$channel = if ($Repository -eq 'releases') { 'release' } else { 'nightly' }
+$lockStr = "ponyup-$channel-$pkgVersion-$PlatformStringArch-windows"
+Write-Host "Locking ponyup version to $lockStr..."
+$lockPath = "$ponyupPath\.lock"
 
-  $newContent = @()
-  if (Test-Path $lockPath) {
-    $content = Get-Content -Path $lockPath
-    $content | Foreach-Object {
-      if ($_ -match '^ponyup') {
-        $newContent += $lockStr
-      }
-      else {
-        $newContent += $_
-      }
+$newContent = @()
+if (Test-Path $lockPath) {
+  $content = Get-Content -Path $lockPath
+  $content | Foreach-Object {
+    if ($_ -match '^ponyup') {
+      $newContent += $lockStr
     }
-  } else {
-    $newContent = @($lockStr)
+    else {
+      $newContent += $_
+    }
   }
-
-  Set-Content -Path "$ponyupPath\.lock" -Value $newContent
+} else {
+  $newContent = @($lockStr)
 }
+
+Set-Content -Path "$ponyupPath\.lock" -Value $newContent
 
 if ($SetPath) {
   $binDir = "$ponyupPath\bin"


### PR DESCRIPTION
Gives `ponyup-init.ps1` CI coverage on both Windows architectures, mirroring how the Linux and macOS bootstrap jobs exercise `ponyup-init.sh` via `.ci-scripts/test-bootstrap.sh`.

x86-64 Windows bootstrap runs on every PR (tier 1); arm64 Windows bootstrap runs nightly and on dispatch (tier 2). A new `.ci-scripts/test-bootstrap.ps1` is the PowerShell analog of `test-bootstrap.sh`.

To install nightly ponyup the way the existing jobs do, `ponyup-init.ps1` gains a `-Repository` option, builds its lock string from the Cloudsmith package version (a nightly's version is a date, not the binary's semver), and verifies the download's SHA-256 checksum before extracting — closing a gap where the Windows installer verified nothing.

This is internal CI plumbing: the `-Repository` option exists to serve the bootstrap script (end users run the installer with no args), so there is no release note or changelog entry.

Closes #414