### PR TITLE
Pin cloudsmith-cli below 1.19.0 on arm64 Windows CI

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -156,7 +156,12 @@ jobs:
         run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
-          python.exe -m pip install --upgrade cloudsmith-cli
+          # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
+          # dependency that pulls in cryptography, which has no prebuilt
+          # win_arm64 wheel and fails to build from source on this runner.
+          # Remove once arm64 Windows can install the latest cloudsmith-cli
+          # again.
+          python.exe -m pip install --upgrade "cloudsmith-cli<1.19.0"
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch;
           .\make.ps1 -Command build;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,12 @@ jobs:
         run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
-          python.exe -m pip install --upgrade cloudsmith-cli
+          # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
+          # dependency that pulls in cryptography, which has no prebuilt
+          # win_arm64 wheel and fails to build from source on this runner.
+          # Remove once arm64 Windows can install the latest cloudsmith-cli
+          # again.
+          python.exe -m pip install --upgrade "cloudsmith-cli<1.19.0"
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch;
           .\make.ps1 -Command build;


### PR DESCRIPTION
cloudsmith-cli 1.19.0 added a PyJWT[crypto] dependency that pulls in cryptography, which has no prebuilt win_arm64 wheel. pip then builds it from source on the windows-11-arm runners, which needs OpenSSL and fails, breaking the arm64 Windows nightly (and would break the arm64 release the same way).

Pin below 1.19.0 — which resolves to 1.18.0, the last release without the crypto extra — on the arm64 Windows steps only. x86 Windows, Linux, and macOS install the latest fine, so they're left untouched.