### PR TITLE
Make Windows build-and-upload steps fail fast on native command errors

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -99,6 +99,10 @@ jobs:
         run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
+          # Fail the step on the first failing native command; pwsh treats a
+          # non-zero native exit as non-fatal by default.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           python.exe -m pip install --upgrade cloudsmith-cli
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch;
@@ -106,11 +110,6 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version  --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/nightlies build\ponyup-x86-64-pc-windows-msvc.zip
-          # In a pwsh step the step's exit code is that of the last native
-          # command, so a Cloudsmith failure would be masked by a subsequent
-          # successful GHCR push. Guard it: Cloudsmith is the primary download
-          # source and must not fail silently.
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Additionally publish to GHCR, reusing $version so both destinations
           # get the same date.
           python .ci-scripts\release\ghcr_nightly.py push ponyup x86-64-pc-windows-msvc $version build\ponyup-x86-64-pc-windows-msvc.zip
@@ -156,6 +155,10 @@ jobs:
         run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
+          # Fail the step on the first failing native command; pwsh treats a
+          # non-zero native exit as non-fatal by default.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
           # dependency that pulls in cryptography, which has no prebuilt
           # win_arm64 wheel and fails to build from source on this runner.
@@ -168,11 +171,6 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Date).ToString("yyyyMMdd"); cloudsmith push raw --version $version  --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/nightlies build\ponyup-arm64-pc-windows-msvc.zip
-          # In a pwsh step the step's exit code is that of the last native
-          # command, so a Cloudsmith failure would be masked by a subsequent
-          # successful GHCR push. Guard it: Cloudsmith is the primary download
-          # source and must not fail silently.
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Additionally publish to GHCR, reusing $version so both destinations
           # get the same date.
           python .ci-scripts\release\ghcr_nightly.py push ponyup arm64-pc-windows-msvc $version build\ponyup-arm64-pc-windows-msvc.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,6 +159,10 @@ jobs:
         run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
+          # Fail the step on the first failing native command; pwsh treats a
+          # non-zero native exit as non-fatal by default.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           python.exe -m pip install --upgrade cloudsmith-cli
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch;
@@ -166,7 +170,6 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/releases build\ponyup-x86-64-pc-windows-msvc.zip
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python .ci-scripts\release\github_release.py upload $version build\ponyup-x86-64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
@@ -202,6 +205,10 @@ jobs:
         run: .ci-scripts\windows-install-libressl.ps1
       - name: Build and upload
         run: |
+          # Fail the step on the first failing native command; pwsh treats a
+          # non-zero native exit as non-fatal by default.
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           # Pin cloudsmith-cli below 1.19.0: 1.19.0 added a PyJWT[crypto]
           # dependency that pulls in cryptography, which has no prebuilt
           # win_arm64 wheel and fails to build from source on this runner.
@@ -214,7 +221,6 @@ jobs:
           .\make.ps1 -Command install;
           .\make.ps1 -Command package;
           $version = (Get-Content .\VERSION); cloudsmith push raw --version $version --api-key $env:CLOUDSMITH_API_KEY --summary "The Pony toolchain multiplexer" --description "https://github.com/ponylang/ponyup" ponylang/releases build\ponyup-arm64-pc-windows-msvc.zip
-          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           python .ci-scripts\release\github_release.py upload $version build\ponyup-arm64-pc-windows-msvc.zip
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}


### PR DESCRIPTION
The Windows `Build and upload` steps in `nightlies.yml` and `release.yml` run a chain of native commands in a single pwsh block — `pip install cloudsmith-cli`, the build, then the Cloudsmith push — with a `$LASTEXITCODE` guard only after the push. In pwsh a non-zero exit from a native command is not fatal by default, so a failure in an earlier command did not stop the step; it ran on and the real error got buried until the guard fired much later.

This sets `$ErrorActionPreference = 'Stop'` together with `$PSNativeCommandUseErrorActionPreference = $true` at the top of each of the four Windows build-and-upload blocks, turning native non-zero exits into terminating errors so the step stops at the first failure. That also covers the Cloudsmith-push case the manual `$LASTEXITCODE` guard handled, so the guard is removed.

`make.ps1` is unaffected: it already sets `$ErrorActionPreference = 'Stop'` and guards every native call with an explicit `$LastExitCode` check, and these steps never invoke its `test` path.

Note: the fix relies on the runners executing `run:` steps under pwsh >= 7.4, where `$PSNativeCommandUseErrorActionPreference` is a settable preference. Modern Windows runner images ship this, but it is worth eyeballing the first post-merge `windows-11-arm` run.

corral (and likely ponyc) have the identical structure and will need the same fix in their own repos.

Closes #443