### PR TITLE
Add Alpine 3.24 as a supported platform

### DIFF
--- a/.ci-dockerfiles/alpine3.24-bootstrap-tester/Dockerfile
+++ b/.ci-dockerfiles/alpine3.24-bootstrap-tester/Dockerfile
@@ -1,0 +1,12 @@
+FROM alpine:3.24
+
+LABEL org.opencontainers.image.source="https://github.com/ponylang/ponyup"
+
+RUN apk add --update --no-cache \
+     binutils-gold \
+     build-base \
+     clang \
+     curl \
+     git \
+     libressl-dev \
+     make

--- a/.ci-dockerfiles/alpine3.24-bootstrap-tester/build-and-push.bash
+++ b/.ci-dockerfiles/alpine3.24-bootstrap-tester/build-and-push.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+#
+# *** You should already be logged in to GHCR when you run this ***
+#
+
+NAME="ghcr.io/ponylang/ponyup-ci-alpine3.24-bootstrap-tester"
+TODAY=$(date +%Y%m%d)
+DOCKERFILE_DIR="$(dirname "$0")"
+BUILDER="alpine3.24-builder-$(date +%s)"
+
+docker buildx create --use --name "${BUILDER}"
+docker buildx build --provenance false --sbom false --platform linux/arm64,linux/amd64 --pull --push -t "${NAME}:${TODAY}" "${DOCKERFILE_DIR}"
+docker buildx rm "${BUILDER}"

--- a/.github/workflows/build-bootstrap-tester-image.yml
+++ b/.github/workflows/build-bootstrap-tester-image.yml
@@ -11,6 +11,7 @@ on:
           - alpine3.21-bootstrap-tester
           - alpine3.22-bootstrap-tester
           - alpine3.23-bootstrap-tester
+          - alpine3.24-bootstrap-tester
           - ubuntu24.04-bootstrap-tester
           - ubuntu26.04-bootstrap-tester
 
@@ -80,6 +81,27 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         run: bash .ci-dockerfiles/alpine3.23-bootstrap-tester/build-and-push.bash
+
+  alpine3_24-bootstrap-tester:
+    if: ${{ github.event.inputs.builder-name == 'alpine3.24-bootstrap-tester' }}
+    runs-on: ubuntu-latest
+
+    name: alpine3.24-bootstrap-tester
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          version: v0.23.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: bash .ci-dockerfiles/alpine3.24-bootstrap-tester/build-and-push.bash
 
   ubuntu24_04-bootstrap-tester:
     if: ${{ github.event.inputs.builder-name == 'ubuntu24.04-bootstrap-tester' }}

--- a/.github/workflows/ponyup-tier2.yml
+++ b/.github/workflows/ponyup-tier2.yml
@@ -163,6 +163,44 @@ jobs:
           topic: ${{ github.repository }} scheduled job failure
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
+  arm64-alpine3_24-bootstrap:
+    needs: check-for-changes
+    if: needs.check-for-changes.outputs.has-changes == 'true'
+    name: arm64 Alpine 3.24 bootstrap
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.2
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull Docker image
+        run: docker pull ghcr.io/ponylang/ponyup-ci-alpine3.24-bootstrap-tester:20260614
+      - name: Bootstrap test
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/root/project \
+            -w /root/project \
+            -e SSL=libressl \
+            ghcr.io/ponylang/ponyup-ci-alpine3.24-bootstrap-tester:20260614 \
+            .ci-scripts/test-bootstrap.sh
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   # Currently, GitHub actions supplied by GH like checkout and cache do not work
   # in musl libc environments on arm64. We can work around this by running
   # those actions on the host and then "manually" doing our work that would

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,6 +28,16 @@ jobs:
       - name: Bootstrap test
         run: SSL=libressl .ci-scripts/test-bootstrap.sh
 
+  x86-64-alpine3_24-bootstrap:
+    name: x86-64 Alpine 3.24 bootstrap
+    runs-on: ubuntu-latest
+    container:
+        image: ghcr.io/ponylang/ponyup-ci-alpine3.24-bootstrap-tester:20260614
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Bootstrap test
+        run: SSL=libressl .ci-scripts/test-bootstrap.sh
+
   x86-64-ubuntu26_04-bootstrap:
     name: x86-64 Ubuntu 26.04 bootstrap
     runs-on: ubuntu-latest

--- a/.release-notes/alpine3.24.md
+++ b/.release-notes/alpine3.24.md
@@ -1,0 +1,3 @@
+## Add Alpine 3.24 as a supported platform
+
+We've added support for Alpine 3.24. This means that if you are using `ponyup` on an arm64 or amd64 system with Alpine 3.24, it will now recognize it as a supported platform and allow you to install `ponyc` and other related packages.

--- a/ponyup-init.sh
+++ b/ponyup-init.sh
@@ -112,6 +112,9 @@ Linux*)
     ;;
   *musl)
     case "$(cat /etc/alpine-release)" in
+    *3.24.*)
+      platform_triple_distro="alpine3.24"
+      ;;
     *3.23.*)
       platform_triple_distro="alpine3.23"
       ;;


### PR DESCRIPTION
Adds Alpine 3.24 as a supported bootstrap-test platform. Bootstrap-tester image, CI bootstrap jobs (x86-64 tier 1, arm64 tier 2), and `ponyup-init.sh` detection are all included.

The `test/main.pony` platform fixture is intentionally left at alpine3.23: its release-channel integration tests download real ponyc releases, and Alpine 3.24 has nightlies only, no release yet. The fixture should track the latest Alpine that has ponyc releases.