### PR TITLE
Use org-wide delete-packages token for nightly GHCR pruning

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -270,7 +270,7 @@ jobs:
         uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53
         with:
           account: ponylang
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PONYLANG_MAIN_DELETE_PACKAGE_TOKEN }}
           image-names: "nightly/ponyup-*"
           tag-selection: tagged
           cut-off: 90d


### PR DESCRIPTION
The nightly GHCR prune step fails because `snok/container-retention-policy` cannot list packages by wildcard (`nightly/<name>-*`) with the repo-scoped `GITHUB_TOKEN` — the GitHub API forbids package listing for that token type, so the step errors with "filtering with '!' and '*' are not supported for this token type".

Switch the prune token to the org-wide `PONYLANG_MAIN_DELETE_PACKAGE_TOKEN`, a classic PAT carrying `read:packages` + `delete:packages`, which can both enumerate and delete the wildcard-matched nightly images. This restores the delete-packages-PAT approach used before the recent switch to `GITHUB_TOKEN`.
