### PR TITLE
Bump alpine test fixture to alpine3.24

### DIFF
--- a/test/main.pony
+++ b/test/main.pony
@@ -874,7 +874,7 @@ primitive _TestPonyup
     if Platform.windows() then
       "x86_64-pc-windows-msvc"
     else
-      "x86_64-linux-alpine3.23"
+      "x86_64-linux-alpine3.24"
     end
 
   fun check_files(h: TestHelper, root: FilePath, pkg: Package) ? =>


### PR DESCRIPTION
The release-channel integration tests download a real ponyc release for the fixture's platform, so the fixture has to track the latest Alpine that has ponyc releases. ponyc 0.65.0 ships alpine3.24 artifacts.