### PR TITLE
Update courier to 0.4.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -14,3 +14,11 @@ We no longer support Alpine 3.22. Alpine 3.23 and 3.24 are still supported.
 
 We no longer support Ubuntu 22.04. Ubuntu 24.04 and 26.04 are still supported.
 
+## Fix downloads closed mid-transfer by the idle timeout
+
+A download could be closed by the connection's idle timeout while it was still transferring. A large download arriving slowly over a slow link looked idle even though data was still moving, so the connection was closed mid-download and the download failed. A connection is now closed by the idle timeout only when no data has moved for the timeout, so slow downloads complete.
+
+## Remove support for Windows 10
+
+ponyup no longer runs on Windows 10. Running ponyup on Windows now requires Windows 11 or Windows Server 2022 or later. Other platforms are unaffected.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. This projec
 ### Fixed
 
 - Fix response never arriving after sending a large request ([PR #449](https://github.com/ponylang/ponyup/pull/449))
+- Fix downloads closed mid-transfer by the idle timeout ([PR #453](https://github.com/ponylang/ponyup/pull/453))
 
 ### Added
 
@@ -16,6 +17,7 @@ All notable changes to this project will be documented in this file. This projec
 - Remove support for Alpine 3.21 ([PR #451](https://github.com/ponylang/ponyup/pull/451))
 - Remove support for Alpine 3.22 ([PR #451](https://github.com/ponylang/ponyup/pull/451))
 - Remove support for Ubuntu 22.04 ([PR #452](https://github.com/ponylang/ponyup/pull/452))
+- Remove support for Windows 10 ([PR #453](https://github.com/ponylang/ponyup/pull/453))
 
 ## [0.15.5] - 2026-06-14
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ From there the team can either point you at an existing platform identifier or a
 
 ## Development
 
-Building from source requires ponyc 0.64.0 or later.
+Building from source requires ponyc 0.64.0 or later. On Windows, building from source requires ponyc 0.66.0 or later.
 
 ### Vendored LibreSSL
 

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.3.1"
+      "version": "0.4.0"
     }
   ],
   "info": {


### PR DESCRIPTION
Picks up courier's fix for downloads being cut off mid-transfer by the idle timeout, and drops Windows 10 support — ponyup no longer runs on Windows 10 (Windows 11 / Server 2022 or later required).