### PR TITLE
Use a hyphen instead of an en-dash in make.ps1

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -70,7 +70,7 @@ Write-Host "Version:          $Version"
 Write-Host "Root directory:   $rootDir"
 Write-Host "Source directory: $srcDir"
 Write-Host "Build directory:  $buildDir"
-Write-Host "Processors: $((Get-CimInstance –ClassName Win32_Processor).NumberOfLogicalProcessors)"
+Write-Host "Processors: $((Get-CimInstance -ClassName Win32_Processor).NumberOfLogicalProcessors)"
 Write-Host "Memory Capacity: $((Get-CimInstance -ClassName Win32_PhysicalMemory).Capacity)"
 
 # generate pony templated files if necessary


### PR DESCRIPTION
Line 73 of make.ps1 used an en-dash (`–`) instead of a hyphen before `ClassName` in the `Get-CimInstance` call that prints the processor count. The en-dash breaks script parsing under Windows PowerShell 5.1, so make.ps1 cannot run there at all. pwsh 7 tolerated it, which is why CI never caught it.

The en-dash was introduced in #325.