### PR TITLE
Pin actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/update-libressl.yml
+++ b/.github/workflows/update-libressl.yml
@@ -26,7 +26,7 @@ jobs:
         run: bash .ci-scripts/build-macos-libressl.bash
         env:
           LIBRESSL_VERSION: ${{ inputs.version }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: libressl-darwin-arm64
           path: lib/darwin-arm64/*.a
@@ -40,7 +40,7 @@ jobs:
         run: bash .ci-scripts/build-macos-libressl.bash
         env:
           LIBRESSL_VERSION: ${{ inputs.version }}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@v7.0.1
         with:
           name: libressl-darwin-x86-64
           path: lib/darwin-x86-64/*.a


### PR DESCRIPTION
This repo pinned `actions/upload-artifact` to the floating `v7` major tag while pinning its other first-party actions to exact patch versions (`checkout@v6.0.2`, `cache@v5.0.3`). Pinning to `v7.0.1` makes the ref reproducible and consistent with the rest of the repo, and matches the version ponyc is being moved to in ponylang/ponyc#5751.

No behavior change: `v7` already resolved to `v7.0.1`.