### PR TITLE
Pin actions/download-artifact to v8.0.1

### DIFF
--- a/.github/workflows/update-libressl.yml
+++ b/.github/workflows/update-libressl.yml
@@ -53,11 +53,11 @@ jobs:
       - uses: actions/checkout@v6.0.2
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v8.0.1
         with:
           name: libressl-darwin-arm64
           path: lib/darwin-arm64/
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@v8.0.1
         with:
           name: libressl-darwin-x86-64
           path: lib/darwin-x86-64/


### PR DESCRIPTION
Follow-on to #456. `download-artifact` was the last first-party action here still on a floating major tag (`v8`); everything else is pinned to an exact patch version (`checkout@v6.0.2`, `cache@v5.0.3`, `upload-artifact@v7.0.1`).

No behavior change: `v8` already resolved to `v8.0.1`. This just makes the ref reproducible.