### PR TITLE
Shuffle test order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ SOURCE_FILES := $(shell find cmd -name \*.pony)
 test: $(binary)
 	corral fetch
 	corral run -- ponyc $(PONYC_FLAGS) $(LINKER) test -o $(BUILD_DIR) -b test
-	$(BUILD_DIR)/test --sequential
+	$(BUILD_DIR)/test --sequential --shuffle
 
 clean:
 	corral clean

--- a/make.ps1
+++ b/make.ps1
@@ -195,8 +195,8 @@ switch ($Command.ToLower())
   "test"
   {
     $testFile = (BuildTest)[-1]
-    Write-Host "$testFile --sequential"
-    & "$testFile" --sequential
+    Write-Host "$testFile --sequential --shuffle"
+    & "$testFile" --sequential --shuffle
     if ($LastExitCode -ne 0) { throw "Error" }
     break
   }


### PR DESCRIPTION
Add `--shuffle` to the test runs so tests execute in a randomized order, which surfaces hidden dependencies between tests.
