### PR TITLE
Stop disabling Windows Defender in CI

### DIFF
--- a/.github/workflows/breakage-against-windows-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-windows-ponyc-latest.yml
@@ -12,8 +12,6 @@ jobs:
     name: Verify main against the latest ponyc on Windows
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Install pony tools
         run: |

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -76,8 +76,6 @@ jobs:
     name: Build and upload x86-64-pc-windows-msvc-nightly
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
@@ -132,8 +130,6 @@ jobs:
     name: Build and upload arm64-pc-windows-msvc-nightly
     runs-on: windows-11-arm
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |

--- a/.github/workflows/ponyup-tier2.yml
+++ b/.github/workflows/ponyup-tier2.yml
@@ -221,8 +221,6 @@ jobs:
     name: arm64 Windows tests
     runs-on: windows-11-arm
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}
@@ -268,8 +266,6 @@ jobs:
     name: arm64 Windows bootstrap
     runs-on: windows-11-arm
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
         with:
           ref: ${{ inputs.ref || github.sha }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,8 +67,6 @@ jobs:
     name: x86-64 Windows bootstrap
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -111,8 +109,6 @@ jobs:
     name: x86-64 Windows tests
     runs-on: windows-2025-vs2026
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,8 +136,6 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
@@ -182,8 +180,6 @@ jobs:
     needs:
       - pre-artefact-creation
     steps:
-      - name: Disable Windows Defender
-        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |


### PR DESCRIPTION
Remove the "Disable Windows Defender" step from the Windows CI jobs. It doesn't speed the jobs up, and the step occasionally fails on some runners.
