### PR TITLE
Fix download stability issues

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,11 @@
+## Fix downloads hanging after completion
+
+Downloading a package could hang after all data had been received, leaving ponyup stuck until killed.
+
+## Fix downloads failing on macOS
+
+On macOS, downloading a package could fail when connecting to a host that resolves to more than one address. Cloudsmith, where ponyup downloads packages from, is one such host. Linux and Windows were not affected.
+
+## Fix HTTPS downloads silently losing data or failing
+
+Several bugs in HTTPS connection handling could cause downloads to fail, data to be silently dropped, or one connection's failure to break a different connection. These could show up as unexplained download failures or checksum mismatches.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix downloads hanging after completion ([PR #463](https://github.com/ponylang/ponyup/pull/463))
+- Fix downloads failing on macOS ([PR #463](https://github.com/ponylang/ponyup/pull/463))
+- Fix HTTPS downloads silently losing data or failing ([PR #463](https://github.com/ponylang/ponyup/pull/463))
 
 ### Added
 

--- a/cmd/http_handlers.pony
+++ b/cmd/http_handlers.pony
@@ -309,7 +309,7 @@ actor DLDump
   let _fail_cb: {()} val
   let _file_name: String
   let _file: File
-  let _digest: ssl_crypto.Digest = ssl_crypto.Digest.sha512()
+  let _digest: ssl_crypto.Digest
   var _total: USize = 0
   var _progress: USize = 0
   var _percent: USize = 0
@@ -318,12 +318,14 @@ actor DLDump
     notify: PonyupNotify,
     file_path: FilePath,
     cb: {(String)} val,
+    digest: ssl_crypto.Digest iso,
     fail_cb: {()} val = {() => None})
   =>
     _notify = consume notify
     _file_path = consume file_path
     _cb = consume cb
     _fail_cb = consume fail_cb
+    _digest = consume digest
 
     let components = _file_path.path.split("/")
     _file_name = try components(components.size() - 1)? else "" end
@@ -361,4 +363,5 @@ actor DLDump
   be finished() =>
     _file.dispose()
     _notify.write("\n")
-    _cb(ssl_crypto.ToHexString(_digest.final()))
+    let hash = try ssl_crypto.ToHexString(_digest.final()?) else "" end
+    _cb(hash)

--- a/cmd/ponyup.pony
+++ b/cmd/ponyup.pony
@@ -3,6 +3,7 @@ use "collections"
 use "files"
 use "json"
 use "process"
+use ssl_crypto = "ssl/crypto"
 use "term"
 use "time"
 
@@ -157,12 +158,20 @@ actor Ponyup
       return
     end
 
+    let digest =
+      try
+        recover iso ssl_crypto.Digest.sha512()? end
+      else
+        _notify.log(Err, "unable to initialize SHA-512 digest")
+        return
+      end
     let dump = DLDump(
       _notify,
       dl_path,
       {(checksum')(self = recover tag this end) =>
         self.dl_complete(pkg', install_path, dl_path, checksum, checksum')
       },
+      consume digest,
       {()(self = recover tag this end) => self.dl_failed()})
 
     _http_get.download(download_url, dump)

--- a/corral.json
+++ b/corral.json
@@ -2,7 +2,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.1"
+      "version": "4.0.0"
     },
     {
       "locator": "github.com/ponylang/appdirs.git",
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.4.0"
+      "version": "0.5.0"
     }
   ],
   "info": {


### PR DESCRIPTION
Fixes several connection stability bugs that could cause downloads to hang, fail on macOS, or lose data over HTTPS. Updates courier to 0.5.0 and ssl to 4.0.0.