### PR TITLE
Update to build with ponyc nightly (0.69.0+)

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
       - name: Build and upload
         run: |
           docker run --rm \
@@ -34,7 +34,7 @@ jobs:
             -e GITHUB_REPOSITORY=${{ github.repository }} \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GITHUB_ACTOR=${{ github.actor }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly \
             bash .ci-scripts/release/arm64-unknown-linux-nightly.bash
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -52,7 +52,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
@@ -79,9 +79,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -133,9 +133,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -191,7 +191,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
+        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: |
           brew update
@@ -221,7 +221,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
+        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
       - name: brew install dependencies
         run: |
           brew update

--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,10 +87,10 @@ jobs:
     name: x86-64 Linux tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with the most recent ponyc release
+      - name: Test with the most recent ponyc nightly
         run: make test
 
   arm64-macos:
@@ -99,8 +99,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
-      - name: Test with the most recent ponyc release
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+      - name: Test with the most recent ponyc nightly
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test
@@ -112,9 +112,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -128,7 +128,7 @@ jobs:
       - name: Install LibreSSL
         if: steps.cache-libressl.outputs.cache-hit != 'true'
         run: .ci-scripts\windows-install-libressl.ps1
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch 2>&1

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ From there the team can either point you at an existing platform identifier or a
 
 ## Development
 
-Building from source requires ponyc 0.64.0 or later. On Windows, building from source requires ponyc 0.66.0 or later.
+Building from source requires ponyc 0.69.0 or later.
 
 ### Vendored LibreSSL
 

--- a/cmd/ponyup_notify.pony
+++ b/cmd/ponyup_notify.pony
@@ -632,7 +632,7 @@ actor Ponyup
       end
 
     let expand_monitor =
-      ProcessMonitor(
+      match \exhaustive\ StartProcess(
         StartProcessAuth(_auth),
         ApplyReleaseBackpressureAuth(_auth),
         object iso is ProcessNotify
@@ -679,6 +679,11 @@ actor Ponyup
           command
         ],
         _env.vars)
+      | let pm: ProcessMonitor => pm
+      | let err: ProcessError =>
+        _notify.log(Err, "failed to extract archive")
+        return
+      end
     expand_monitor.done_writing()
 
   fun ref _extract_archive_posix(
@@ -696,7 +701,7 @@ actor Ponyup
       end
 
     let tar_monitor =
-      ProcessMonitor(
+      match \exhaustive\ StartProcess(
         StartProcessAuth(_auth),
         ApplyReleaseBackpressureAuth(_auth),
         object iso is ProcessNotify
@@ -727,6 +732,11 @@ actor Ponyup
           "--strip-components"; "1"
         ],
         _env.vars)
+      | let pm: ProcessMonitor => pm
+      | let err: ProcessError =>
+        _notify.log(Err, "failed to extract archive")
+        return
+      end
 
     tar_monitor.done_writing()
 


### PR DESCRIPTION
ponyc removed the public `ProcessMonitor` constructor in favor of the `StartProcess` factory, which returns `(ProcessMonitor | ProcessError)`. Both extraction call sites now match on the result.

PR and nightly workflows switched from release to nightly ponyc since the `ProcessMonitor` change hasn't been released yet.
