### PR TITLE
Switch ponyup-tier2.yml from release to nightly ponyc

### DIFF
--- a/.github/workflows/ponyup-tier2.yml
+++ b/.github/workflows/ponyup-tier2.yml
@@ -145,13 +145,13 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
-      - name: Test with most recent ponyc release
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+      - name: Test with most recent ponyc nightly
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/root/project \
             -w /root/project \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly \
             make test
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -226,9 +226,9 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -242,7 +242,7 @@ jobs:
       - name: Install LibreSSL
         if: steps.cache-libressl.outputs.cache-hit != 'true'
         run: .ci-scripts\windows-install-libressl.ps1
-      - name: Test with most recent ponyc release
+      - name: Test with most recent ponyc nightly
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch 2>&1
@@ -305,8 +305,8 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: install pony tools
-        run: bash .ci-scripts/macos-x86-install-pony-tools.bash release
-      - name: Test with the most recent ponyc release
+        run: bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
+      - name: Test with the most recent ponyc nightly
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test


### PR DESCRIPTION
The tier 2 workflow was missed in #471 when pr.yml, nightlies.yml, and pony-lint.yml were switched to nightly. ponyup now requires ponyc 0.69.0+ APIs (`StartProcess`) that aren't in the 0.68.0 release, so the three test jobs in ponyup-tier2.yml that still pulled release ponyc were failing.

Also added ponyup-tier2.yml to the post-release task list on ponylang/ponyc#5802.
