### PR TITLE
Fix pony-lint findings, bump courier, and switch workflows back to release

### DIFF
--- a/.github/workflows/breakage-against-linux-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-linux-ponyc-latest.yml
@@ -9,6 +9,27 @@ permissions:
   packages: read
 
 jobs:
+  pony-lint:
+    name: Lint against ponyc main
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   vs-ponyc-main-linux:
     name: Verify main against ponyc main on Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
       - name: Build and upload
         run: |
           docker run --rm \
@@ -34,7 +34,7 @@ jobs:
             -e GITHUB_REPOSITORY=${{ github.repository }} \
             -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
             -e GITHUB_ACTOR=${{ github.actor }} \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release \
             bash .ci-scripts/release/arm64-unknown-linux-nightly.bash
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -52,7 +52,7 @@ jobs:
     name: Build and upload x86-64-unknown-linux-nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Build and upload
@@ -79,9 +79,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -133,9 +133,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -191,7 +191,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
+        run:  bash .ci-scripts/macos-x86-install-pony-tools.bash release
       - name: brew install dependencies
         run: |
           brew update
@@ -221,7 +221,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
+        run:  bash .ci-scripts/macos-arm64-install-pony-tools.bash release
       - name: brew install dependencies
         run: |
           brew update

--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/ponyup-tier2.yml
+++ b/.github/workflows/ponyup-tier2.yml
@@ -145,13 +145,13 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: Pull Docker image
-        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
-      - name: Test with most recent ponyc nightly
+        run: docker pull ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      - name: Test with most recent ponyc release
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/root/project \
             -w /root/project \
-            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly \
+            ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release \
             make test
       - name: Send alert on failure
         if: ${{ failure() }}
@@ -226,9 +226,9 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-arm64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Force -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-arm64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Force -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -242,7 +242,7 @@ jobs:
       - name: Install LibreSSL
         if: steps.cache-libressl.outputs.cache-hit != 'true'
         run: .ci-scripts\windows-install-libressl.ps1
-      - name: Test with most recent ponyc nightly
+      - name: Test with most recent ponyc release
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch 2>&1
@@ -305,8 +305,8 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.sha }}
       - name: install pony tools
-        run: bash .ci-scripts/macos-x86-install-pony-tools.bash nightly
-      - name: Test with the most recent ponyc nightly
+        run: bash .ci-scripts/macos-x86-install-pony-tools.bash release
+      - name: Test with the most recent ponyc release
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -87,10 +87,10 @@ jobs:
     name: x86-64 Linux tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
     steps:
       - uses: actions/checkout@v6.0.2
-      - name: Test with the most recent ponyc nightly
+      - name: Test with the most recent ponyc release
         run: make test
 
   arm64-macos:
@@ -99,8 +99,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash nightly
-      - name: Test with the most recent ponyc nightly
+        run: bash .ci-scripts/macos-arm64-install-pony-tools.bash release
+      - name: Test with the most recent ponyc release
         run: |
           export PATH="/tmp/corral/bin:/tmp/ponyc/bin/:$PATH"
           make test
@@ -112,9 +112,9 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
         run: |
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/ponyc-x86-64-pc-windows-msvc.zip -OutFile C:\ponyc.zip;
           Expand-Archive -Path C:\ponyc.zip -DestinationPath C:\ponyc;
-          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/nightlies/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
+          Invoke-WebRequest https://dl.cloudsmith.io/public/ponylang/releases/raw/versions/latest/corral-x86-64-pc-windows-msvc.zip -OutFile C:\corral.zip;
           Expand-Archive -Path C:\corral.zip -DestinationPath C:\ponyc;
       - name: Cache LibreSSL libs
         id: cache-libressl
@@ -128,7 +128,7 @@ jobs:
       - name: Install LibreSSL
         if: steps.cache-libressl.outputs.cache-hit != 'true'
         run: .ci-scripts\windows-install-libressl.ps1
-      - name: Test with most recent ponyc nightly
+      - name: Test with most recent ponyc release
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
           .\make.ps1 -Command fetch 2>&1

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ From there the team can either point you at an existing platform identifier or a
 
 ## Development
 
-Building from source requires ponyc 0.69.0 or later.
+Building from source requires ponyc 0.69.1 or later.
 
 ### Vendored LibreSSL
 

--- a/cmd/_os.pony
+++ b/cmd/_os.pony
@@ -139,8 +139,8 @@ primitive Packages
         if i == (platform'.size() - 1) then distro = field end
       end
     end
-    if (application.name() == "ponyc")
-      and platform_requires_distro(os)
+    if (application.name() == "ponyc") and
+      platform_requires_distro(os)
     then
       if distro is None then error end
     else

--- a/cmd/http_handlers.pony
+++ b/cmd/http_handlers.pony
@@ -7,7 +7,7 @@ use lori = "lori"
 use ssl_net = "ssl/net"
 use uri = "uri"
 
-type QueryResult is (Array[JsonObject val] iso | QueryError)
+type QueryResult is (Array[JSONObject val] iso | QueryError)
 
 primitive QueryError
   """
@@ -192,8 +192,8 @@ actor _QueryConnection is courier.HTTPClientConnectionActor
       end
     _notify.log(
       Err,
-      "query: connection to " + _host
-        + " failed: " + reason_str)
+      "query: connection to " + _host +
+        " failed: " + reason_str)
     _cb(QueryError)
 
   fun ref on_parse_error(err: courier.ParseError) =>
@@ -215,15 +215,15 @@ actor _QueryConnection is courier.HTTPClientConnectionActor
       end
     _notify.log(
       Err,
-      "query: HTTP parse error from " + _host
-        + ": " + err_str)
+      "query: HTTP parse error from " + _host +
+        ": " + err_str)
     _cb(QueryError)
 
   fun ref on_response(response: courier.Response val) =>
     _notify.log(
       Extra,
-      "query: response " + response.status.string()
-        + " " + response.reason)
+      "query: response " + response.status.string() +
+        " " + response.reason)
     for (name, value) in response.headers.values() do
       _notify.log(Extra, "query: header " + name + ": " + value)
     end
@@ -239,18 +239,18 @@ actor _QueryConnection is courier.HTTPClientConnectionActor
       _http.cancel_timer(t)
       _timer = None
     end
-    let result = recover Array[JsonObject val] end
+    let result = recover Array[JSONObject val] end
     try
       let response = _collector.build()?
       let body_str = String.from_array(response.body)
       _notify.log(
         Extra,
-        "query: received response of size "
-          + body_str.size().string())
-      match JsonParser.parse(body_str)
-      | let arr: JsonArray =>
+        "query: received response of size " +
+          body_str.size().string())
+      match JSONParser.parse(body_str)
+      | let arr: JSONArray =>
         for v in arr.values() do
-          try result.push(v as JsonObject) end
+          try result.push(v as JSONObject) end
         end
       end
     end
@@ -263,8 +263,8 @@ actor _QueryConnection is courier.HTTPClientConnectionActor
       _timer = None
       _notify.log(
         Err,
-        "query: timed out waiting for " + _host
-          + ", try again or increase --api-timeout")
+        "query: timed out waiting for " + _host +
+          ", try again or increase --api-timeout")
       _cb(QueryError)
       _http.close()
     end
@@ -272,8 +272,8 @@ actor _QueryConnection is courier.HTTPClientConnectionActor
   fun ref on_timer_failure() =>
     _notify.log(
       Err,
-      "query: failed to arm timeout timer for " + _host
-        + ", aborting request")
+      "query: failed to arm timeout timer for " + _host +
+        ", aborting request")
     _cb(QueryError)
     _http.close()
 
@@ -355,8 +355,8 @@ actor _DownloadConnection is courier.HTTPClientConnectionActor
       end
     _notify.log(
       Err,
-      "download: connection to " + _host + " failed: "
-        + reason_str)
+      "download: connection to " + _host + " failed: " +
+        reason_str)
     _dump.failed()
 
   fun ref on_parse_error(err: courier.ParseError) =>
@@ -378,15 +378,15 @@ actor _DownloadConnection is courier.HTTPClientConnectionActor
       end
     _notify.log(
       Err,
-      "download: HTTP parse error from " + _host
-        + ": " + err_str)
+      "download: HTTP parse error from " + _host +
+        ": " + err_str)
     _dump.failed()
 
   fun ref on_response(response: courier.Response val) =>
     _notify.log(
       Extra,
-      "download: response " + response.status.string()
-        + " " + response.reason)
+      "download: response " + response.status.string() +
+        " " + response.reason)
     for (name, value) in response.headers.values() do
       _notify.log(
         Extra, "download: header " + name + ": " + value)
@@ -406,8 +406,8 @@ actor _DownloadConnection is courier.HTTPClientConnectionActor
       _first_chunk_logged = true
       _notify.log(
         Extra,
-        "download: first chunk received, "
-          + data.size().string() + " bytes")
+        "download: first chunk received, " +
+          data.size().string() + " bytes")
     end
     _dump.chunk(data)
 
@@ -419,8 +419,8 @@ actor _DownloadConnection is courier.HTTPClientConnectionActor
     end
     _notify.log(
       Extra,
-      "download: complete, " + _bytes_received.string()
-        + " total bytes received")
+      "download: complete, " + _bytes_received.string() +
+        " total bytes received")
     _dump.finished()
     _http.close()
 
@@ -430,10 +430,10 @@ actor _DownloadConnection is courier.HTTPClientConnectionActor
       _timer = None
       _notify.log(
         Err,
-        "download: timed out after receiving "
-          + _bytes_received.string()
-          + " bytes from " + _host
-          + ", try again or increase --download-timeout")
+        "download: timed out after receiving " +
+          _bytes_received.string() +
+          " bytes from " + _host +
+          ", try again or increase --download-timeout")
       _dump.failed()
       _http.close()
     end
@@ -441,8 +441,8 @@ actor _DownloadConnection is courier.HTTPClientConnectionActor
   fun ref on_timer_failure() =>
     _notify.log(
       Err,
-      "download: failed to arm timeout timer for " + _host
-        + ", aborting download")
+      "download: failed to arm timeout timer for " + _host +
+        ", aborting download")
     _dump.failed()
     _http.close()
 

--- a/cmd/main.pony
+++ b/cmd/main.pony
@@ -62,8 +62,8 @@ actor Main is PonyupNotify
     then
       log(
         Err,
-        "unable to create root directory: "
-          + ponyup_dir.path)
+        "unable to create root directory: " +
+          ponyup_dir.path)
     end
 
     match command.fullname()
@@ -83,8 +83,8 @@ actor Main is PonyupNotify
       else
         log(
           Err,
-          "unable to create lockfile ("
-            + ponyup_dir.path + "/.lock)")
+          "unable to create lockfile (" +
+            ponyup_dir.path + "/.lock)")
         return
       end
 
@@ -291,8 +291,8 @@ actor Main is PonyupNotify
       if level is InternalErr then
         _env.out
           .> write(
-            "Internal error encountered. "
-              + "Please open an issue at ")
+            "Internal error encountered. " +
+              "Please open an issue at ")
           .> print("https://github.com/ponylang/ponyup")
       end
     end

--- a/cmd/ponyup_notify.pony
+++ b/cmd/ponyup_notify.pony
@@ -116,9 +116,9 @@ actor Ponyup
     """
     Handles a Cloudsmith API response for a package query.
     """
-    let res: Array[JsonObject val] iso =
+    let res: Array[JSONObject val] iso =
       match \exhaustive\ consume result
-      | let r: Array[JsonObject val] iso => consume r
+      | let r: Array[JSONObject val] iso => consume r
       | QueryError =>
         _notify.log(
           Err, "query for " + pkg.string() + " failed")
@@ -249,9 +249,9 @@ actor Ponyup
       | let pkg: Package =>
         _notify.log(
           Info,
-          "retrying in 3 seconds ("
-            + _sync_retries_remaining.string()
-            + " retries remaining)")
+          "retrying in 3 seconds (" +
+            _sync_retries_remaining.string() +
+            " retries remaining)")
         let self: Ponyup tag = this
         let timer =
           Timer(
@@ -305,16 +305,16 @@ actor Ponyup
           for installed in
             local_packages(p.name()).values()
           do
-            if (installed.channel == p.channel)
-              and (installed.version > latest)
+            if (installed.channel == p.channel) and
+              (installed.version > latest)
             then
               latest = installed.version
             end
           end
           _notify.log(
             Info,
-            "selecting latest version: "
-              + p.channel + "-" + latest)
+            "selecting latest version: " +
+              p.channel + "-" + latest)
           p = pkg.update_version(latest)
         end
         if p.version == "" then error end
@@ -323,8 +323,8 @@ actor Ponyup
       else
         _notify.log(
           Err,
-          "cannot select package " + pkg.string()
-            + ", try installing it first")
+          "cannot select package " + pkg.string() +
+            ", try installing it first")
         return
       end
     consume pkg
@@ -365,13 +365,13 @@ actor Ponyup
           end
           // It is ok for optional binaries to not exist.
           // If they don't then we just skip them.
-          if (not binary.required)
-            and (not bin_path.exists())
+          if (not binary.required) and
+            (not bin_path.exists())
           then
             _notify.log(
               Info,
-              "optional binary isn't in package."
-                + " skipping.")
+              "optional binary isn't in package." +
+                " skipping.")
             continue
           end
           with file = File.create(link_path) do
@@ -410,13 +410,13 @@ actor Ponyup
           end
           // It is ok for optional binaries to not exist.
           // If they don't then we just skip them.
-          if (not binary.required)
-            and (not bin_path.exists())
+          if (not binary.required) and
+            (not bin_path.exists())
           then
             _notify.log(
               Info,
-              "optional binary isn't in package."
-                + " skipping.")
+              "optional binary isn't in package." +
+                " skipping.")
             continue
           end
           if not bin_path.symlink(link_path) then
@@ -452,16 +452,16 @@ actor Ponyup
           for installed in
             local_packages(p.name()).values()
           do
-            if (installed.channel == p.channel)
-              and (installed.version > latest)
+            if (installed.channel == p.channel) and
+              (installed.version > latest)
             then
               latest = installed.version
             end
           end
           _notify.log(
             Info,
-            "resolving latest version: "
-              + p.channel + "-" + latest)
+            "resolving latest version: " +
+              p.channel + "-" + latest)
           p = pkg.update_version(latest)
         end
         if p.version == "" then error end
@@ -469,8 +469,8 @@ actor Ponyup
       else
         _notify.log(
           Err,
-          "no installed " + pkg.channel
-            + " version found for " + pkg.name())
+          "no installed " + pkg.channel +
+            " version found for " + pkg.name())
         return
       end
 
@@ -499,16 +499,16 @@ actor Ponyup
         if not pkg_dir.remove() then
           _notify.log(
             Err,
-            "unable to remove directory: "
-              + pkg_dir.path)
+            "unable to remove directory: " +
+              pkg_dir.path)
           return
         end
       end
     else
       _notify.log(
         Err,
-        "invalid path: " + _root.path
-          + "/" + pkg'.string())
+        "invalid path: " + _root.path +
+          "/" + pkg'.string())
       return
     end
 
@@ -581,8 +581,8 @@ actor Ponyup
       }
     let packages = recover Array[Package] end
     for pkg in _lockfile.string().split("\n").values() do
-      if (pkg != "")
-        and not starts_with(package_name, pkg)
+      if (pkg != "") and
+        not starts_with(package_name, pkg)
       then
         continue
       end
@@ -625,10 +625,10 @@ actor Ponyup
 
     let command =
       recover val
-        "\"Expand-Archive -Force -Path '"
-          + src_path.path
-          + "' -DestinationPath '"
-          + dest_path.path + "'\""
+        "\"Expand-Archive -Force -Path '" +
+          src_path.path +
+          "' -DestinationPath '" +
+          dest_path.path + "'\""
       end
 
     let expand_monitor =
@@ -929,8 +929,8 @@ actor ShowPackages
               name, channel, "latest", target)?
           let query_str =
             recover val
-              Cloudsmith.repo_url(channel)
-                + Cloudsmith.query(pkg)
+              Cloudsmith.repo_url(channel) +
+                Cloudsmith.query(pkg)
             end
           _notify.log(Extra, "query url: " + query_str)
           let token: _QueryToken val = _QueryToken
@@ -943,7 +943,7 @@ actor ShowPackages
               pkg)
             =>
               match consume result
-              | let res: Array[JsonObject val] iso =>
+              | let res: Array[JSONObject val] iso =>
                 try
                   let version =
                     (consume res)(0)?("version")?
@@ -979,8 +979,8 @@ actor ShowPackages
 
     for pkg in _local.values() do
       _notify.write(
-        pkg.string()
-          + if pkg.selected then " *" else "" end,
+        pkg.string() +
+          if pkg.selected then " *" else "" end,
         if pkg.selected then
           ANSI.bright_green()
         else
@@ -1021,7 +1021,7 @@ actor FindPackages
   let _http_get: HTTPGet
   let _application_name: String
   let _channels: Array[String] val
-  embed _results: Array[(String, Array[JsonObject val] val)] =
+  embed _results: Array[(String, Array[JSONObject val] val)] =
     []
   embed _pending: SetIs[_QueryToken val] =
     SetIs[_QueryToken val]
@@ -1044,8 +1044,8 @@ actor FindPackages
     for ch in channels.values() do
       let query_str =
         recover val
-          Cloudsmith.repo_url(ch)
-            + Cloudsmith.find_query(
+          Cloudsmith.repo_url(ch) +
+            Cloudsmith.find_query(
                 application_name,
                 platform,
                 page_size,
@@ -1062,13 +1062,13 @@ actor FindPackages
           ch)
         =>
           match \exhaustive\ consume result
-          | let res: Array[JsonObject val] iso =>
+          | let res: Array[JSONObject val] iso =>
             self.response(token, ch, consume res)
           | QueryError =>
             self.response(
               token,
               ch,
-              recover Array[JsonObject val] end)
+              recover Array[JSONObject val] end)
           end
         })
     end
@@ -1078,7 +1078,7 @@ actor FindPackages
   be response(
     token: _QueryToken val,
     channel: String,
-    res: Array[JsonObject val] iso)
+    res: Array[JSONObject val] iso)
   =>
     _pending.unset(token)
     _results.push((channel, consume res))
@@ -1124,12 +1124,12 @@ actor FindPackages
     vw = vw + 2
 
     _notify.write(
-      _pad("Tool", tw) + _pad("Channel", cw)
-        + _pad("Version", vw) + "Platform\n")
+      _pad("Tool", tw) + _pad("Channel", cw) +
+        _pad("Version", vw) + "Platform\n")
     for (t, c, v, f) in rows.values() do
       _notify.write(
-        _pad(t, tw) + _pad(c, cw)
-          + _pad(v, vw) + f + "\n")
+        _pad(t, tw) + _pad(c, cw) +
+          _pad(v, vw) + f + "\n")
     end
 
   fun _pad(s: String, width: USize): String =>

--- a/corral.json
+++ b/corral.json
@@ -10,7 +10,7 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.6.0"
+      "version": "0.7.0"
     },
     {
       "locator": "github.com/ponylang/uri.git",

--- a/test/main.pony
+++ b/test/main.pony
@@ -4,7 +4,7 @@ use "pony_test"
 use "time"
 use "../cmd"
 
-actor Main is TestList
+actor \nodoc\ Main is TestList
   new create(env: Env) =>
     let test_dir =
       FilePath(FileAuth(env.root), _TestDir.base())
@@ -250,38 +250,38 @@ actor _FindTester is PonyupNotify
 
   be check_results() =>
     _h.log(
-      "check_results: row_count="
-        + _row_count.string()
-        + " got_pkg=" + _got_pkg.string()
-        + " had_error=" + _had_error.string()
-        + " filenames=" + _filenames.size().string())
+      "check_results: row_count=" +
+        _row_count.string() +
+        " got_pkg=" + _got_pkg.string() +
+        " had_error=" + _had_error.string() +
+        " filenames=" + _filenames.size().string())
     if _had_error then
       _h.log("error detail: " + _error_msg)
     end
     _h.assert_true(
       _got_pkg,
-      "expected output containing " + _pkg
-        + " (row_count=" + _row_count.string()
-        + ", had_error=" + _had_error.string() + ")")
+      "expected output containing " + _pkg +
+        " (row_count=" + _row_count.string() +
+        ", had_error=" + _had_error.string() + ")")
     _h.assert_true(
       _row_count > 0,
-      "expected results but got none"
-        + if _had_error then
-            " (error: " + _error_msg + ")"
-          else
-            ""
-          end)
+      "expected results but got none" +
+        if _had_error then
+          " (error: " + _error_msg + ")"
+        else
+          ""
+        end)
     if _max_rows > 0 then
       _h.assert_true(
         _row_count <= _max_rows,
-        "expected at most " + _max_rows.string()
-          + " results, got " + _row_count.string())
+        "expected at most " + _max_rows.string() +
+          " results, got " + _row_count.string())
     end
     if _check_multi_platform then
       _h.assert_true(
         _filenames.size() > 1,
-        "expected results for multiple platforms, got "
-          + _filenames.size().string())
+        "expected results for multiple platforms, got " +
+          _filenames.size().string())
     end
     _h.complete(true)
 
@@ -300,12 +300,12 @@ actor _FindTester is PonyupNotify
     if str.contains("Tool") then return end
     _row_count = _row_count + 1
     if str.contains(_pkg) then _got_pkg = true end
-    if (_check_channel != "")
-      and (not str.contains(_check_channel))
+    if (_check_channel != "") and
+      (not str.contains(_check_channel))
     then
       _h.fail(
-        "row should contain "
-          + _check_channel + ": " + str)
+        "row should contain " +
+          _check_channel + ": " + str)
     end
     if _check_multi_platform then
       let trimmed: String val =
@@ -363,41 +363,41 @@ actor \nodoc\ _SyncTester is PonyupNotify
           pkg)
         =>
           match \exhaustive\ consume result
-          | let res: Array[JsonObject val] iso =>
+          | let res: Array[JSONObject val] iso =>
             self.add_packages(pkg, consume res)
           | QueryError =>
             self.add_packages(
               pkg,
-              recover Array[JsonObject val] end)
+              recover Array[JSONObject val] end)
           end
         })
     end
 
   be add_packages(
     pkg: Package,
-    res: Array[JsonObject val] iso)
+    res: Array[JSONObject val] iso)
   =>
     let count = res.size()
     _h.log(
-      "query returned " + count.string()
-        + " results for " + _application.name())
+      "query returned " + count.string() +
+        " results for " + _application.name())
     if count == 0 then
       _h.log(
-        "WARNING: Cloudsmith query returned zero "
-          + "results for " + _application.name())
+        "WARNING: Cloudsmith query returned zero " +
+          "results for " + _application.name())
     end
     for obj in (consume res).values() do
       try
         let file = obj("filename")? as String
         let version = obj("version")? as String
         _h.log(
-          "  found: " + file
-            + " (version " + version + ")")
+          "  found: " + file +
+            " (version " + version + ")")
         _pkgs.push(pkg.update_version(version))
       else
         _h.log(
-          "  skipped entry: missing filename "
-            + "or version field")
+          "  skipped entry: missing filename " +
+            "or version field")
       end
     end
     run()
@@ -406,16 +406,16 @@ actor \nodoc\ _SyncTester is PonyupNotify
     if _pkgs.size() == 0 then
       if _processed == 0 then
         _h.fail(
-          "sync: query returned no installable "
-            + "packages for " + _application.name()
-            + " -- Cloudsmith may be rate-limiting "
-            + "or unreachable")
+          "sync: query returned no installable " +
+            "packages for " + _application.name() +
+            " -- Cloudsmith may be rate-limiting " +
+            "or unreachable")
         _h.complete(false)
       else
         _h.log(
-          "sync: finished " + _processed.string()
-            + " packages for "
-            + _application.name())
+          "sync: finished " + _processed.string() +
+            " packages for " +
+            _application.name())
         _h.complete(true)
       end
       return
@@ -449,8 +449,8 @@ actor \nodoc\ _SyncTester is PonyupNotify
           p
         end
       _h.log(
-        "sync -- " + pkg.name()
-          + "/" + pkg.channel)
+        "sync -- " + pkg.name() +
+          "/" + pkg.channel)
       ponyup.sync(pkg, 3)
     else
       _h.fail("sync setup error")
@@ -564,14 +564,14 @@ actor \nodoc\ _SelectTester is PonyupNotify
         _h.complete(true)
       else
         _h.fail(
-          "unexpected complete at step "
-            + _step.string())
+          "unexpected complete at step " +
+            _step.string())
         _h.complete(false)
       end
     else
       _h.fail(
-        "select test failed at step "
-          + _step.string())
+        "select test failed at step " +
+          _step.string())
       _h.complete(false)
     end
 
@@ -597,16 +597,16 @@ actor \nodoc\ _SelectTester is PonyupNotify
       end
       if not found then
         _h.fail(
-          "batch file did not contain version "
-            + version)
+          "batch file did not contain version " +
+            version)
         error
       end
     else
       let target = link.canonical()?.path
       if not target.contains(version) then
         _h.fail(
-          "symlink " + target
-            + " should point to version " + version)
+          "symlink " + target +
+            " should point to version " + version)
         error
       end
     end
@@ -698,19 +698,19 @@ actor \nodoc\ _RemoveTester is PonyupNotify
         let pkg_dir = root.join(pkg_a.string())?
         _h.assert_false(
           pkg_dir.exists(),
-          "package directory should have been "
-            + "removed: " + pkg_dir.path)
+          "package directory should have been " +
+            "removed: " + pkg_dir.path)
         _h.complete(true)
       else
         _h.fail(
-          "unexpected complete at step "
-            + _step.string())
+          "unexpected complete at step " +
+            _step.string())
         _h.complete(false)
       end
     else
       _h.fail(
-        "remove test failed at step "
-          + _step.string())
+        "remove test failed at step " +
+          _step.string())
       _h.complete(false)
     end
 
@@ -718,8 +718,8 @@ actor \nodoc\ _RemoveTester is PonyupNotify
     _h.log(msg)
     match level
     | InternalErr | Err =>
-      if (_step == 2)
-        and msg.contains("cannot remove")
+      if (_step == 2) and
+        msg.contains("cannot remove")
       then
         _step = 3
         try
@@ -728,8 +728,8 @@ actor \nodoc\ _RemoveTester is PonyupNotify
           ponyup.remove(pkg_a)
         else
           _h.fail(
-            "remove test: failed to extract "
-              + "fields at step 3")
+            "remove test: failed to extract " +
+              "fields at step 3")
           _h.complete(false)
         end
       else
@@ -935,8 +935,8 @@ actor \nodoc\ _OptionalBinariesPresentTester
       ponyup.select(pkg)
     else
       h.fail(
-        "failed to set up optional binaries "
-          + "present test")
+        "failed to set up optional binaries " +
+          "present test")
       h.complete(false)
     end
 
@@ -1020,8 +1020,8 @@ actor \nodoc\ _OptionalBinariesAbsentTester
       ponyup.select(pkg)
     else
       h.fail(
-        "failed to set up optional binaries "
-          + "absent test")
+        "failed to set up optional binaries " +
+          "absent test")
       h.complete(false)
     end
 
@@ -1114,8 +1114,8 @@ actor \nodoc\ _OptionalBinariesPartialTester
       ponyup.select(pkg)
     else
       h.fail(
-        "failed to set up optional binaries "
-          + "partial test")
+        "failed to set up optional binaries " +
+          "partial test")
       h.complete(false)
     end
 
@@ -1188,10 +1188,10 @@ primitive _TestPonyup
     let bin_path =
       root.join(pkg.string())?.join("bin")?
         .join(
-          pkg.name()
-            + ifdef windows then ".exe"
-              else ""
-              end)?
+          pkg.name() +
+            ifdef windows then ".exe"
+            else ""
+            end)?
     h.assert_true(bin_path.exists())
 
   fun stage_package(
@@ -1235,16 +1235,16 @@ primitive _TestPonyup
     """
     let link_path =
       root.join("bin")?.join(
-        binary_name
-          + ifdef windows then ".bat"
-            else ""
-            end)?
+        binary_name +
+          ifdef windows then ".bat"
+          else ""
+          end)?
     let source_path =
       root.join(pkg.string())?.join("bin")?.join(
-        binary_name
-          + ifdef windows then ".exe"
-            else ""
-            end)?
+        binary_name +
+          ifdef windows then ".exe"
+          else ""
+          end)?
     ifdef windows then
       var found = false
       with file = File.open(link_path) do
@@ -1257,8 +1257,8 @@ primitive _TestPonyup
       end
       if not found then
         h.fail(
-          "bat file did not reference source "
-            + source_path.path)
+          "bat file did not reference source " +
+            source_path.path)
         error
       end
     else
@@ -1266,8 +1266,8 @@ primitive _TestPonyup
       let expected = source_path.canonical()?.path
       if target != expected then
         h.fail(
-          "link " + target
-            + " should point to " + expected)
+          "link " + target +
+            " should point to " + expected)
         error
       end
     end


### PR DESCRIPTION
Rename Json* to JSON* in ponyup's own code, bump courier to 0.7.0 (JSON rename released there), fix pony-lint operator-spacing and control-structure-alignment findings, add the missing `\nodoc\` on the test Main actor, and flip pr.yml/pony-lint.yml/nightlies.yml/ponyup-tier2.yml back to :release now that 0.69.1 is out. No user-facing changes; no release note or CHANGELOG entry.