### PR TITLE
Update to work with ponyc 0.70.0

### DIFF
--- a/.release-notes/update-to-work-with-ponyc-0.70.0.md
+++ b/.release-notes/update-to-work-with-ponyc-0.70.0.md
@@ -1,0 +1,3 @@
+## Update to work with ponyc 0.70.0
+
+Updated for compatibility with ponyc 0.70.0.

--- a/corral.json
+++ b/corral.json
@@ -2,7 +2,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "4.0.0"
+      "version": "5.0.0"
     },
     {
       "locator": "github.com/ponylang/appdirs.git",
@@ -10,11 +10,11 @@
     },
     {
       "locator": "github.com/ponylang/courier.git",
-      "version": "0.7.0"
+      "version": "0.8.0"
     },
     {
       "locator": "github.com/ponylang/uri.git",
-      "version": "0.3.0"
+      "version": "0.4.0"
     }
   ],
   "info": {


### PR DESCRIPTION
Update ssl dependency to 5.0.0 for ponyc 0.70.0 compatibility.
